### PR TITLE
Follow-up to #96: harden Prisma FK detection and untangle two module boundaries

### DIFF
--- a/src/handlers/Command.ts
+++ b/src/handlers/Command.ts
@@ -2,8 +2,8 @@ import { Client } from 'discord.js';
 import { join } from 'path';
 import { loadSlashCommands, registerSlashCommands } from './commandLoader';
 
-module.exports = (client: Client) => {
+export function registerCommandHandlers(client: Client) {
 	const slashCommandsDir = join(__dirname, '../lib/commands/slashCommands');
 	const slashCommands = loadSlashCommands(slashCommandsDir, client);
 	void registerSlashCommands(slashCommands);
-};
+}

--- a/src/handlers/Event.ts
+++ b/src/handlers/Event.ts
@@ -2,7 +2,7 @@ import { Client } from 'discord.js';
 import { join } from 'path';
 import { loadEvents } from './eventLoader';
 
-module.exports = (client: Client) => {
+export function registerEventHandlers(client: Client) {
 	const eventsDir = join(__dirname, '../events');
 	loadEvents(eventsDir, client);
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export const client = new Client({
 	partials: [Partials.Message, Partials.Channel, Partials.Reaction], //	needed for handling interactions from DM's
 });
 import { SlashCommand } from './types';
+import { registerCommandHandlers } from './handlers/Command';
+import { registerEventHandlers } from './handlers/Event';
 import { config } from 'dotenv';
 import { expand } from 'dotenv-expand';
 import {
@@ -41,11 +43,12 @@ process.on('uncaughtException', (error) => {
 client.slashCommands = new Collection<string, SlashCommand>();
 client.cooldowns = new Collection<string, number>();
 
-// 	Listed explicitly rather than scanned from handlers/: the scan also invoked
+// 	Called explicitly rather than scanned from handlers/: the scan also invoked
 // 	the loader modules, which export named functions instead of a callable, and
-// 	the resulting throw skipped the login() call below.
-require('./handlers/Command')(client);
-require('./handlers/Event')(client);
+// 	the resulting throw skipped the login() call below. Imported rather than
+// 	require()d so a rename of either handler fails the build instead of at boot.
+registerCommandHandlers(client);
+registerEventHandlers(client);
 
 // 	Once logged in discord.js reconnects on its own, but a failure during the
 // 	initial login is fatal. On container start we frequently lose the race with

--- a/src/lib/content/messages/messageBuilder.ts
+++ b/src/lib/content/messages/messageBuilder.ts
@@ -17,11 +17,8 @@ import {
 	formatPriceNumberToReadableString,
 	isSnoozed,
 } from '../../helpers/watches';
-import {
-	AuctionData,
-	ItemType,
-	getEnvironmentVariable,
-} from '../../streams/streamAuction';
+import { AuctionData, ItemType } from '../../streams/streamAuction';
+import { getEnvironmentVariable } from '../../helpers/env';
 import { getImageUrlForItem } from '../../helpers/images';
 import { getWikiUrlFromItem } from '../../helpers/wikiLinks';
 import {

--- a/src/lib/helpers/env.test.ts
+++ b/src/lib/helpers/env.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { getEnvironmentVariable } from './env';
+
+//	A name with no meaning to the rest of the app: the helper is a generic
+//	lookup, so pinning it to a stream channel would imply a coupling that no
+//	longer exists now that it lives outside streamAuction.
+const NAME = 'A_TEST_ONLY_VARIABLE';
+
+function withVariable(value: string | undefined, run: () => void) {
+	const original = process.env[NAME];
+	if (value === undefined) delete process.env[NAME];
+	else process.env[NAME] = value;
+
+	try {
+		run();
+	} finally {
+		//	restored in a finally: a failed assertion would otherwise leak the
+		//	deleted variable into every test that follows
+		if (original === undefined) delete process.env[NAME];
+		else process.env[NAME] = original;
+	}
+}
+
+describe('getEnvironmentVariable', () => {
+	it('returns the value when it is set', () => {
+		withVariable('a-value', () => {
+			expect(getEnvironmentVariable(NAME)).toBe('a-value');
+		});
+	});
+
+	it('throws, naming the variable, when it is missing', () => {
+		withVariable(undefined, () => {
+			expect(() => getEnvironmentVariable(NAME)).toThrow(
+				`Environment variable ${NAME} is not defined.`,
+			);
+		});
+	});
+
+	it('treats an empty value as missing', () => {
+		//	an empty string is almost always an unfilled line in .env rather than
+		//	a deliberate value, so it fails the same way rather than silently
+		//	propagating '' into a channel id
+		withVariable('', () => {
+			expect(() => getEnvironmentVariable(NAME)).toThrow(
+				`Environment variable ${NAME} is not defined.`,
+			);
+		});
+	});
+});

--- a/src/lib/helpers/env.ts
+++ b/src/lib/helpers/env.ts
@@ -1,0 +1,7 @@
+export function getEnvironmentVariable(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Environment variable ${name} is not defined.`);
+	}
+	return value;
+}

--- a/src/lib/helpers/errors.ts
+++ b/src/lib/helpers/errors.ts
@@ -35,8 +35,10 @@ function pruneReportHistory(now: number) {
 }
 
 // 	backstop for floods that dedupe cannot catch, such as errors whose message
-// 	embeds a unique interaction id
-function hasExceededReportRate(now: number) {
+// 	embeds a unique interaction id. Consumes one unit of the per-minute budget
+// 	and reports whether the caller may proceed - it mutates, so it is not a
+// 	predicate and must be called exactly once per report attempt.
+function consumeReportBudget(now: number) {
 	if (now - rateWindowStartedAt >= 60 * 1000) {
 		rateWindowStartedAt = now;
 		reportsInRateWindow = 0;
@@ -50,7 +52,7 @@ function hasExceededReportRate(now: number) {
 		);
 	}
 
-	return reportsInRateWindow > MAX_REPORTS_PER_MINUTE;
+	return reportsInRateWindow <= MAX_REPORTS_PER_MINUTE;
 }
 
 function beginDiscordReport(error: Error, now: number): string | undefined {
@@ -71,7 +73,7 @@ function beginDiscordReport(error: Error, now: number): string | undefined {
 		return undefined;
 	}
 
-	if (hasExceededReportRate(now)) {
+	if (!consumeReportBudget(now)) {
 		return undefined;
 	}
 
@@ -186,6 +188,9 @@ export async function gracefullyHandleError(
 	// 	a throw here would replace a handled error with an unhandled one
 	try {
 		await reportErrorToDiscord(errorMessage, normalizedError, extraData);
+		// 	deliberately not recorded when the send fails: a transient Discord
+		// 	blip should not suppress this error for the whole dedupe window. A
+		// 	sustained outage is bounded by the per-minute budget instead.
 		lastReportedAt.set(reportKey, Date.now());
 	} catch (loggingError) {
 		console.error('ERROR LOGGING ERROR TO DISCORD: ', loggingError);

--- a/src/lib/helpers/removeMessagesFromCommandSpace.ts
+++ b/src/lib/helpers/removeMessagesFromCommandSpace.ts
@@ -35,8 +35,9 @@ export async function removeNoncommandMessagesFromPublicCommandSpace() {
 					BULK_DELETE_MAX_AGE_MS,
 			);
 
-		// 	one request for up to 100 messages; deleting them individually cost a
-		// 	request each, which rate limits hard once a backlog builds up
+		// 	one request instead of one per message, which rate limits hard once a
+		// 	backlog builds up. messages.fetch() returns 50 by default and the
+		// 	endpoint accepts 100, so this always fits in a single call.
 		await textChannel.bulkDelete(recent);
 
 		// 	the bulk endpoint rejects these outright, so they still cost a request

--- a/src/lib/parser/aliasMatching.test.ts
+++ b/src/lib/parser/aliasMatching.test.ts
@@ -4,6 +4,8 @@ vi.mock('../../prisma/init', () => import('../../test/mocks/prisma'));
 vi.mock('../../redis/init', () => import('../../test/mocks/redis'));
 vi.mock('../streams/streamAuction', () => ({
 	streamAuctionToAllStreamChannels: vi.fn(async () => undefined),
+}));
+vi.mock('../helpers/env', () => ({
 	getEnvironmentVariable: (n: string) => process.env[n] ?? '',
 }));
 vi.mock('../watchNotification/watchNotification', () => ({

--- a/src/lib/parser/monitorLogs.test.ts
+++ b/src/lib/parser/monitorLogs.test.ts
@@ -4,6 +4,8 @@ vi.mock('../../prisma/init', () => import('../../test/mocks/prisma'));
 vi.mock('../../redis/init', () => import('../../test/mocks/redis'));
 vi.mock('../streams/streamAuction', () => ({
 	streamAuctionToAllStreamChannels: vi.fn(async () => undefined),
+}));
+vi.mock('../helpers/env', () => ({
 	getEnvironmentVariable: (n: string) => process.env[n] ?? '',
 }));
 vi.mock('../watchNotification/watchNotification', () => ({

--- a/src/lib/streams/streamAuction.test.ts
+++ b/src/lib/streams/streamAuction.test.ts
@@ -14,7 +14,6 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ChannelType } from 'discord.js';
 import { Server } from '../../prisma/client';
 import { streamAuctionToAllStreamChannels } from './streamAuction';
-import { getEnvironmentVariable } from '../helpers/env';
 import { gracefullyHandleError } from '../helpers/errors';
 import {
 	embeddedAuctionStreamMessageBuilder,
@@ -32,21 +31,6 @@ function getChannelSend(channelId: string) {
 	>;
 	return channel.send;
 }
-
-describe('getEnvironmentVariable', () => {
-	it('throws when an environment variable is missing', () => {
-		const original = process.env.SERVERS_BLUE_STREAM_CHANNEL_CLASSIC_ID;
-		delete process.env.SERVERS_BLUE_STREAM_CHANNEL_CLASSIC_ID;
-
-		expect(() =>
-			getEnvironmentVariable('SERVERS_BLUE_STREAM_CHANNEL_CLASSIC_ID'),
-		).toThrow(
-			'Environment variable SERVERS_BLUE_STREAM_CHANNEL_CLASSIC_ID is not defined.',
-		);
-
-		process.env.SERVERS_BLUE_STREAM_CHANNEL_CLASSIC_ID = original;
-	});
-});
 
 describe('streamAuctionToAllStreamChannels', () => {
 	beforeEach(() => {

--- a/src/lib/streams/streamAuction.test.ts
+++ b/src/lib/streams/streamAuction.test.ts
@@ -13,10 +13,8 @@ vi.mock('../content/messages/messageBuilder', () => ({
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ChannelType } from 'discord.js';
 import { Server } from '../../prisma/client';
-import {
-	streamAuctionToAllStreamChannels,
-	getEnvironmentVariable,
-} from './streamAuction';
+import { streamAuctionToAllStreamChannels } from './streamAuction';
+import { getEnvironmentVariable } from '../helpers/env';
 import { gracefullyHandleError } from '../helpers/errors';
 import {
 	embeddedAuctionStreamMessageBuilder,

--- a/src/lib/streams/streamAuction.ts
+++ b/src/lib/streams/streamAuction.ts
@@ -6,14 +6,7 @@ import {
 	packEmbedsForDiscord,
 } from '../content/messages/messageBuilder';
 import { gracefullyHandleError } from '../helpers/errors';
-
-export function getEnvironmentVariable(name: string): string {
-	const value = process.env[name];
-	if (!value) {
-		throw new Error(`Environment variable ${name} is not defined.`);
-	}
-	return value;
-}
+import { getEnvironmentVariable } from '../helpers/env';
 
 export type AuctionData = {
 	buying: ItemType[];

--- a/src/prisma/higherOrderFunctions.test.ts
+++ b/src/prisma/higherOrderFunctions.test.ts
@@ -39,22 +39,6 @@ const SHAPES: Array<[string, Error]> = [
 			},
 		}),
 	],
-	[
-		'Prisma 6 flat field_name',
-		fkError({ meta: { field_name: 'Watch_discordUserId_fkey' } }),
-	],
-	[
-		'Prisma 6 flat constraint',
-		fkError({ meta: { constraint: 'Watch_discordUserId_fkey' } }),
-	],
-	[
-		'message-only fallback',
-		fkError({
-			message:
-				'Foreign key constraint violated on the constraint: `Watch_discordUserId_fkey`',
-			meta: {},
-		}),
-	],
 ];
 
 describe('attemptAndCreateUserIfNeeded', () => {

--- a/src/prisma/higherOrderFunctions.test.ts
+++ b/src/prisma/higherOrderFunctions.test.ts
@@ -1,0 +1,131 @@
+import { vi } from 'vitest';
+vi.mock('./init', () => import('../test/mocks/prisma'));
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attemptAndCreateUserIfNeeded } from './higherOrderFunctions';
+import { prisma } from '../test/mocks/prisma';
+import { makeChatInteraction } from '../test/factories';
+
+//	Prisma has relocated the violated-constraint detail between major versions.
+//	Each shape below shipped in a real release; missing one means lazy user
+//	creation stops working and the user's first command fails.
+function fkError(overrides: Record<string, unknown>) {
+	return Object.assign(new Error('Foreign key constraint violated'), {
+		code: 'P2003',
+		...overrides,
+	});
+}
+
+const SHAPES: Array<[string, Error]> = [
+	[
+		'Prisma 7 driver adapter constraint index',
+		fkError({
+			meta: {
+				driverAdapterError: {
+					cause: {
+						constraint: { index: 'Watch_discordUserId_fkey' },
+					},
+				},
+			},
+		}),
+	],
+	[
+		'Prisma 7 driver adapter constraint fields',
+		fkError({
+			meta: {
+				driverAdapterError: {
+					cause: { constraint: { fields: ['discordUserId'] } },
+				},
+			},
+		}),
+	],
+	[
+		'Prisma 6 flat field_name',
+		fkError({ meta: { field_name: 'Watch_discordUserId_fkey' } }),
+	],
+	[
+		'Prisma 6 flat constraint',
+		fkError({ meta: { constraint: 'Watch_discordUserId_fkey' } }),
+	],
+	[
+		'message-only fallback',
+		fkError({
+			message:
+				'Foreign key constraint violated on the constraint: `Watch_discordUserId_fkey`',
+			meta: {},
+		}),
+	],
+];
+
+describe('attemptAndCreateUserIfNeeded', () => {
+	beforeEach(() => {
+		vi.mocked(prisma.user.upsert).mockClear();
+	});
+
+	it.each(SHAPES)('creates the user and retries for %s', async (_, error) => {
+		const action = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(error)
+			.mockResolvedValueOnce('ok');
+
+		const result = await attemptAndCreateUserIfNeeded(
+			makeChatInteraction(),
+			action,
+		);
+
+		expect(result).toBe('ok');
+		expect(prisma.user.upsert).toHaveBeenCalledTimes(1);
+		expect(action).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not create a user when the action succeeds', async () => {
+		const action = vi.fn(async () => 'ok');
+
+		await expect(
+			attemptAndCreateUserIfNeeded(makeChatInteraction(), action),
+		).resolves.toBe('ok');
+		expect(prisma.user.upsert).not.toHaveBeenCalled();
+	});
+
+	it('rethrows a P2003 raised by an unrelated foreign key', async () => {
+		const error = fkError({
+			message:
+				'Foreign key constraint violated on the constraint: `BlockedPlayerByWatch_watchId_fkey`',
+			meta: {
+				driverAdapterError: {
+					cause: {
+						constraint: {
+							index: 'BlockedPlayerByWatch_watchId_fkey',
+						},
+					},
+				},
+			},
+		});
+		const action = vi.fn().mockRejectedValue(error);
+
+		await expect(
+			attemptAndCreateUserIfNeeded(makeChatInteraction(), action),
+		).rejects.toBe(error);
+		expect(prisma.user.upsert).not.toHaveBeenCalled();
+		expect(action).toHaveBeenCalledTimes(1);
+	});
+
+	it('rethrows non-P2003 errors untouched', async () => {
+		const error = Object.assign(new Error('nope'), { code: 'P2002' });
+		const action = vi.fn().mockRejectedValue(error);
+
+		await expect(
+			attemptAndCreateUserIfNeeded(makeChatInteraction(), action),
+		).rejects.toBe(error);
+		expect(prisma.user.upsert).not.toHaveBeenCalled();
+	});
+
+	it('rethrows non-object throws without inspecting them', async () => {
+		const action = vi.fn().mockRejectedValue('a bare string');
+
+		await expect(
+			attemptAndCreateUserIfNeeded(makeChatInteraction(), action),
+		).rejects.toBe('a bare string');
+		expect(prisma.user.upsert).not.toHaveBeenCalled();
+	});
+});

--- a/src/prisma/higherOrderFunctions.ts
+++ b/src/prisma/higherOrderFunctions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Interaction } from 'discord.js';
 import { prisma } from './init';
 
@@ -6,10 +5,10 @@ import { prisma } from './init';
 //  when they only need to be created once.  let's assume they exist and catch the
 //  the error if it fails.  If it's the specific FK violation error, then create the
 //  user and try again.
-export async function attemptAndCreateUserIfNeeded(
+export async function attemptAndCreateUserIfNeeded<T>(
 	interaction: Interaction,
-	action: () => Promise<any>,
-): Promise<any> {
+	action: () => Promise<T>,
+): Promise<T> {
 	try {
 		return await action();
 	} catch (error) {
@@ -32,23 +31,49 @@ async function ensureUserExists(user: Interaction['user']): Promise<void> {
 	});
 }
 
-//  Prisma 7 reports the violated constraint through the driver adapter's error
-//  cause instead of the flat `meta.constraint`/`meta.field_name` of earlier
-//  versions. Postgres names the constraint (`Watch_discordUserId_fkey`), but
-//  other drivers report bare column names, so check both shapes.
+const USER_FK_COLUMN = 'discordUserId';
+
+//  Prisma has moved this detail twice now: `meta.field_name` in v5/v6, and in
+//  v7 the driver adapter's error cause. Each move silently broke lazy user
+//  creation, because a missed FK violation just rethrows and the user's first
+//  command fails. All three shapes are checked so the next move degrades into
+//  redundancy rather than an outage.
 type ForeignKeyViolationMeta = {
+	//  Prisma 7 + @prisma/adapter-pg. Postgres names the constraint
+	//  (`Watch_discordUserId_fkey`); other drivers report bare column names.
 	driverAdapterError?: {
 		cause?: { constraint?: { index?: string; fields?: string[] } };
 	};
+	//  Prisma 6 and earlier
+	field_name?: string;
+	constraint?: string | string[];
 };
 
-function isForeignKeyViolationError(error: any): boolean {
-	if (error?.code !== 'P2003') return false;
+function isForeignKeyViolationError(error: unknown): boolean {
+	if (!isRecord(error) || error.code !== 'P2003') return false;
 
-	const constraint = (error.meta as ForeignKeyViolationMeta | undefined)
-		?.driverAdapterError?.cause?.constraint;
+	const meta = isRecord(error.meta)
+		? (error.meta as ForeignKeyViolationMeta)
+		: undefined;
+	const constraint = meta?.driverAdapterError?.cause?.constraint;
 
-	return [constraint?.index ?? '', ...(constraint?.fields ?? [])].some(
-		(name) => name.includes('discordUserId'),
+	const candidates = [
+		constraint?.index,
+		...(constraint?.fields ?? []),
+		meta?.field_name,
+		...(Array.isArray(meta?.constraint)
+			? meta.constraint
+			: [meta?.constraint]),
+		//  last resort: the rendered message still names the constraint when
+		//  the structured fields have moved again
+		typeof error.message === 'string' ? error.message : undefined,
+	];
+
+	return candidates.some(
+		(name) => typeof name === 'string' && name.includes(USER_FK_COLUMN),
 	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
 }

--- a/src/prisma/higherOrderFunctions.ts
+++ b/src/prisma/higherOrderFunctions.ts
@@ -33,20 +33,25 @@ async function ensureUserExists(user: Interaction['user']): Promise<void> {
 
 const USER_FK_COLUMN = 'discordUserId';
 
-//  Prisma has moved this detail twice now: `meta.field_name` in v5/v6, and in
-//  v7 the driver adapter's error cause. Each move silently broke lazy user
-//  creation, because a missed FK violation just rethrows and the user's first
-//  command fails. All three shapes are checked so the next move degrades into
-//  redundancy rather than an outage.
+//  Prisma 7 + @prisma/adapter-pg reports the violated constraint through the
+//  driver adapter's error cause. Postgres names the constraint
+//  (`Watch_discordUserId_fkey`); other drivers report bare column names, so both
+//  shapes are checked.
+//
+//  Deliberately no fallbacks for the flat `meta.field_name`/`meta.constraint` of
+//  v5/v6, or for the rendered message. prisma, @prisma/client and
+//  @prisma/adapter-pg are pinned together at ^7.9.1, so those shapes cannot
+//  occur without a deliberate downgrade — and if Prisma relocates this again,
+//  higherOrderFunctions.itest.ts is what catches it: it drives a real P2003
+//  against real Postgres through the same adapter production uses, so the build
+//  goes red before anything ships. Fallbacks would only soften a failure that
+//  had already got past a red build, and matching the message would mean
+//  trusting Prisma's prose to stay put — a weaker assumption than the one about
+//  structured fields this comment declines to make.
 type ForeignKeyViolationMeta = {
-	//  Prisma 7 + @prisma/adapter-pg. Postgres names the constraint
-	//  (`Watch_discordUserId_fkey`); other drivers report bare column names.
 	driverAdapterError?: {
 		cause?: { constraint?: { index?: string; fields?: string[] } };
 	};
-	//  Prisma 6 and earlier
-	field_name?: string;
-	constraint?: string | string[];
 };
 
 function isForeignKeyViolationError(error: unknown): boolean {
@@ -57,19 +62,7 @@ function isForeignKeyViolationError(error: unknown): boolean {
 		: undefined;
 	const constraint = meta?.driverAdapterError?.cause?.constraint;
 
-	const candidates = [
-		constraint?.index,
-		...(constraint?.fields ?? []),
-		meta?.field_name,
-		...(Array.isArray(meta?.constraint)
-			? meta.constraint
-			: [meta?.constraint]),
-		//  last resort: the rendered message still names the constraint when
-		//  the structured fields have moved again
-		typeof error.message === 'string' ? error.message : undefined,
-	];
-
-	return candidates.some(
+	return [constraint?.index, ...(constraint?.fields ?? [])].some(
 		(name) => typeof name === 'string' && name.includes(USER_FK_COLUMN),
 	);
 }


### PR DESCRIPTION
# Harden Prisma FK detection and untangle two module boundaries

Follow-up to #96. Three commits, plus two more addressing review.

## The bug fix

`isForeignKeyViolationError` only read Prisma 7's `driverAdapterError.cause.constraint`. Prisma has relocated this detail before, and each move silently breaks lazy user creation: a missed FK violation just rethrows, so a user's very first command fails.

`attemptAndCreateUserIfNeeded` also becomes generic. Dropping `Promise<any>` restores real return types at both call sites — `upsertWatchSafely` returns `Watch` again, `insertPlayerLinkSafely` returns `string` — and lets the file-wide `no-explicit-any` disable go. `isForeignKeyViolationError` now narrows from `unknown` rather than taking `any`.

## Refactors

**`consumeReportBudget`** (was `hasExceededReportRate`). The old name read as a predicate while mutating counters that must only be touched once per attempt. The existing throttle test in `errors.test.ts` — 12 errors, expects 10 sends — guards the inversion.

**Named handler exports.** `registerCommandHandlers` / `registerEventHandlers` replace `require()` calls in `index.ts`, so renaming either fails the build instead of at boot. Motivated by the boot-time handler failure in #96.

**`getEnvironmentVariable`** moves out of `streamAuction` into `lib/helpers/env.ts`. The parser tests were stubbing it through a whole-module `vi.mock` factory, which silently replaces every export of that module; a precise mock is far less likely to rot.

## Review follow-ups

**Moved the `getEnvironmentVariable` tests** into `src/lib/helpers/env.test.ts` alongside the helper. The variable they exercise is now a neutral name rather than `SERVERS_BLUE_STREAM_CHANNEL_CLASSIC_ID`, which implied a coupling that no longer exists. Adds the two cases the original lacked (a set value is returned; an empty value is rejected like a missing one) and restores state in a `finally`, so a failed assertion can't leak a deleted variable into later tests.

**Dropped the v5/v6 FK fallbacks and the message fallback.** `prisma`, `@prisma/client` and `@prisma/adapter-pg` are pinned together at `^7.9.1`, so the flat `meta.field_name` / `meta.constraint` shapes can't occur without a deliberate downgrade — the three fixtures asserting them were testing inputs this codebase cannot produce.

The fallbacks also weren't what protected against the next relocation. `higherOrderFunctions.itest.ts` is: it drives a real `P2003` against real Postgres through the same adapter production uses, so a moved field turns the build red before anything ships. And matching `error.message` meant trusting Prisma's prose format while the comment above it declined to trust the structured fields — the weaker of the two assumptions.

Kept the `unknown` + `isRecord` typing, both driver-adapter shapes (`index` and `fields`, since non-Postgres drivers report bare column names), and every negative test — including the `BlockedPlayerByWatch` case, which is the one that could actually bite.

## Verification

530 unit tests, 55 integration tests, lint and typecheck clean. The integration suite needs Docker running.

## Note

#103 is stacked on this branch and should merge second.
