### PR TITLE
Add headless P99 Green and Blue log collectors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,9 @@
 
 # Secrets and local configuration
 .env*
+p99-logger/*.json
+p99-logger/data
+logs
 
 # Reinstalled or regenerated inside the image
 node_modules

--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,9 @@ HISTORICAL_AUCTION_DATA_API=https://pigparse.azurewebsites.net
 
 # Example 1: "C:\EverQuest\Logs" -> "//c/everquest/logs" (capitalization is not relevant)
 # Example 2: "C:\EverQuest\Logs" -> "C:\\everquest\\logs\\" (double slashes and trailing slash REQUIRED)
-LOG_SOURCE_PATH="C:\\Program Files (x86)\\Sony\\EverQuest\\Logs\\"
+# Empty local directory for fake logs or headless collectors. When reading
+# EverQuest client logs, replace this with their actual directory.
+LOG_SOURCE_PATH=./logs
 
 # Name of log files (not including path, specify that above)
 SERVERS_BLUE_LOG_FILE=eqlog_Mychar_project1999.txt
@@ -70,6 +72,18 @@ SERVERS_RED_LOG_FILE=eqlog_Mychar_P1999PVP.txt
 # SERVERS_*_LOG_FILE values above are placeholders, and tailing them would fail.
 # Set it to false only once those point at a real EverQuest install.
 FAKE_LOGS=true
+
+# Optional headless P99 collectors. Copy the example JSON files under
+# p99-logger/, set these paths, and start Compose with --profile p99-loggers.
+# SERVERS_BLUE_LOG_FILE_PATH=/p99-logger/blue/chat.jsonl
+# SERVERS_GREEN_LOG_FILE_PATH=/p99-logger/green/chat.jsonl
+# SERVERS_RED_LOG_FILE_PATH=/p99-logger/red/chat.log
+P99_LOGGER_IMAGE=ghcr.io/rm-you/p99-logger-client:sha-fbb036a
+P99_BLUE_CONFIG_FILE=./p99-logger/blue.json
+P99_GREEN_CONFIG_FILE=./p99-logger/green.json
+# Replace these with the output of `id -u` and `id -g` on Linux.
+P99_UID=1000
+P99_GID=1000
 
 ####################################
 ### DO NOT TOUCH BELOW THIS LINE ###

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ src/prisma/generated
 !.vscode/settings.json
 .idea
 .claude
+
+# Local P99 login credentials and collected chat logs
+/logs/
+p99-logger/*.json
+!p99-logger/*.example.json
+p99-logger/data/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,55 @@ docker compose up --build
 
 Set `LOG_SOURCE_PATH` and the `SERVERS_*_LOG_FILE` names in `.env` first, or set
 `FAKE_LOGS=true` to run the container stack without a game client.
+`LOG_SOURCE_PATH` defaults to `./logs`; point it at your EverQuest log directory
+when reading client logs.
+
+## Headless P99 log collectors
+
+The optional `p99-loggers` Compose profile runs one
+[`p99-logger-client`](https://github.com/rm-you/p99-logger-client) container
+for Green and another for Blue. Each character logs in without the EverQuest
+client and appends auction and OOC messages to a private JSONL file.
+TunnelQuestBot reads auction messages and player-link requests from those JSONL
+files alongside the original EverQuest text-log format.
+
+Copy the two templates and replace only the login account, password, and
+existing character for each server. The public Green and Blue server names and
+all connection and output settings are already filled in:
+
+```sh
+cp p99-logger/green.example.json p99-logger/green.json
+cp p99-logger/blue.example.json p99-logger/blue.json
+chmod 600 p99-logger/green.json p99-logger/blue.json
+```
+
+The credential files are ignored by Git and excluded from Docker build
+contexts. Both accounts and characters must already exist. The pinned logger
+image includes the current P99 asset checksum inventory, so users do not need
+an EverQuest installation or separate asset configuration. In `.env`, set
+`FAKE_LOGS=false` and uncomment the three `SERVERS_*_LOG_FILE_PATH` values under
+the headless collector section. Set `P99_UID` and `P99_GID` to the owner of the
+two private configuration files; on Linux these are normally the output of
+`id -u` and `id -g`. The Red path points to an empty initialized log because
+there is no Red collector.
+
+Leave `LOG_SOURCE_PATH=./logs` for headless collection; Compose creates this
+unused directory automatically. Log-file initialization runs before the bot in
+every configuration. Keep the `p99-loggers` profile enabled to run the collectors
+and receive new messages.
+
+Start the bot and collectors with:
+
+```sh
+docker compose --profile p99-loggers pull p99-green-logger p99-blue-logger
+docker compose --profile p99-loggers up -d --build
+docker compose --profile p99-loggers ps
+docker compose logs -f p99-green-logger p99-blue-logger tunnelquestbot
+```
+
+The credential files, JSONL logs, and health state are kept out of the bot
+image. The collectors run without capabilities, with read-only root
+filesystems, and use a named volume shared read-only with the bot.
 
 ## Running In Production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,78 @@ services:
         retries: 12
         start_period: 20s
 
+    p99-logger-init:
+      image: busybox:1.37.0
+      environment:
+        P99_UID: "${P99_UID:-65534}"
+        P99_GID: "${P99_GID:-65534}"
+      command:
+        - sh
+        - -ec
+        - |
+          mkdir -p /data/green /data/blue /data/red
+          touch /data/green/chat.jsonl /data/blue/chat.jsonl /data/red/chat.log
+          chown -R "$$P99_UID:$$P99_GID" /data/green /data/blue /data/red
+          chmod 750 /data/green /data/blue /data/red
+          chmod 640 /data/green/chat.jsonl /data/blue/chat.jsonl /data/red/chat.log
+      volumes:
+        - p99-logger-data:/data
+      restart: "no"
+
+    p99-green-logger:
+      image: "${P99_LOGGER_IMAGE:-ghcr.io/rm-you/p99-logger-client:sha-fbb036a}"
+      profiles: ["p99-loggers"]
+      user: "${P99_UID:-65534}:${P99_GID:-65534}"
+      command: ["/config/config.json"]
+      depends_on:
+        p99-logger-init:
+          condition: service_completed_successfully
+      volumes:
+        - type: bind
+          source: "${P99_GREEN_CONFIG_FILE:-./p99-logger/green.json}"
+          target: /config/config.json
+          read_only: true
+          bind:
+            create_host_path: false
+        - p99-logger-data:/data
+      read_only: true
+      cap_drop: ["ALL"]
+      security_opt: ["no-new-privileges:true"]
+      restart: unless-stopped
+      healthcheck:
+        test: ["CMD", "/p99-logger-client", "health", "/data/green/health.json"]
+        interval: 30s
+        timeout: 5s
+        retries: 3
+        start_period: 60s
+
+    p99-blue-logger:
+      image: "${P99_LOGGER_IMAGE:-ghcr.io/rm-you/p99-logger-client:sha-fbb036a}"
+      profiles: ["p99-loggers"]
+      user: "${P99_UID:-65534}:${P99_GID:-65534}"
+      command: ["/config/config.json"]
+      depends_on:
+        p99-logger-init:
+          condition: service_completed_successfully
+      volumes:
+        - type: bind
+          source: "${P99_BLUE_CONFIG_FILE:-./p99-logger/blue.json}"
+          target: /config/config.json
+          read_only: true
+          bind:
+            create_host_path: false
+        - p99-logger-data:/data
+      read_only: true
+      cap_drop: ["ALL"]
+      security_opt: ["no-new-privileges:true"]
+      restart: unless-stopped
+      healthcheck:
+        test: ["CMD", "/p99-logger-client", "health", "/data/blue/health.json"]
+        interval: 30s
+        timeout: 5s
+        retries: 3
+        start_period: 60s
+
     tunnelquestbot:
       build:
         context: .
@@ -50,17 +122,23 @@ services:
           condition: service_healthy
         redis:
           condition: service_healthy
+        p99-logger-init:
+          condition: service_completed_successfully
       environment:
-        SERVERS_BLUE_LOG_FILE_PATH: "/logfiles/${SERVERS_BLUE_LOG_FILE}"
-        SERVERS_GREEN_LOG_FILE_PATH: "/logfiles/${SERVERS_GREEN_LOG_FILE}"
-        SERVERS_RED_LOG_FILE_PATH: "/logfiles/${SERVERS_RED_LOG_FILE}"
+        SERVERS_BLUE_LOG_FILE_PATH: "${SERVERS_BLUE_LOG_FILE_PATH:-/logfiles/${SERVERS_BLUE_LOG_FILE}}"
+        SERVERS_GREEN_LOG_FILE_PATH: "${SERVERS_GREEN_LOG_FILE_PATH:-/logfiles/${SERVERS_GREEN_LOG_FILE}}"
+        SERVERS_RED_LOG_FILE_PATH: "${SERVERS_RED_LOG_FILE_PATH:-/logfiles/${SERVERS_RED_LOG_FILE}}"
         REDIS_SOCKET_DIR: "${REDIS_SOCKET_DIR}"
         FAKE_LOGS: "${FAKE_LOGS:-false}"
         DEBUG_MODE: "${DEBUG_MODE:-false}"
       volumes:
         - type: bind
-          source: "${LOG_SOURCE_PATH}"
+          source: "${LOG_SOURCE_PATH:-./logs}"
           target: /logfiles
+        - type: volume
+          source: p99-logger-data
+          target: /p99-logger
+          read_only: true
         - type: bind
           source: ".env"
           target: /app/.env
@@ -79,3 +157,4 @@ volumes:
   db-socket:
   redis-socket:
   redis-data:
+  p99-logger-data:

--- a/p99-logger/blue.example.json
+++ b/p99-logger/blue.example.json
@@ -1,0 +1,9 @@
+{
+  "user": "EXAMPLE_BLUE_LOGIN_ACCOUNT",
+  "pass": "EXAMPLE_BLUE_PASSWORD",
+  "server": "Project 1999: Blue (Velious, PvE)",
+  "character": "ExampleBlueCharacter",
+  "channels": ["auc", "ooc"],
+  "output": "/data/blue/chat.jsonl",
+  "health": "/data/blue/health.json"
+}

--- a/p99-logger/green.example.json
+++ b/p99-logger/green.example.json
@@ -1,0 +1,9 @@
+{
+  "user": "EXAMPLE_GREEN_LOGIN_ACCOUNT",
+  "pass": "EXAMPLE_GREEN_PASSWORD",
+  "server": "Project 1999: Green (Velious, PvE)",
+  "character": "ExampleGreenCharacter",
+  "channels": ["auc", "ooc"],
+  "output": "/data/green/chat.jsonl",
+  "health": "/data/green/health.json"
+}

--- a/src/lib/parser/monitorLogs.test.ts
+++ b/src/lib/parser/monitorLogs.test.ts
@@ -17,7 +17,7 @@ vi.mock('../playerLink/playerLink', () => ({
 
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { Server } from '../../prisma/client';
-import { handleLogLine, generateAuctionKey } from './monitorLogs';
+import { handleLogLine, generateAuctionKey, parseLogLine } from './monitorLogs';
 import { state } from './state';
 import { initializeGroupedWatches } from '../../prisma/dbExecutors/watch';
 import { streamAuctionToAllStreamChannels } from '../streams/streamAuction';
@@ -26,6 +26,25 @@ import { handleLinkMatch } from '../playerLink/playerLink';
 import { redis } from '../../test/mocks/redis';
 
 const LINK_CODE = '12345678-1234-1234-1234-123456789012';
+
+function p99LoggerRecord(overrides: Record<string, unknown> = {}): string {
+	return JSON.stringify({
+		timestamp: '2026-09-05T12:34:56.789Z',
+		server: 'Project 1999: Blue (Velious, PvE)',
+		character: 'ExampleCharacter',
+		zone: 'ecommons',
+		session_id: 'example-session',
+		message_id: 1,
+		type: 'chat',
+		opcode: 4100,
+		channel: 4,
+		channel_name: 'auction',
+		sender: 'Soandso',
+		target: '',
+		text: 'WTS FBSS 100pp',
+		...overrides,
+	});
+}
 
 describe('handleLogLine', () => {
 	beforeEach(() => {
@@ -68,6 +87,40 @@ describe('handleLogLine', () => {
 		expect(triggerFoundWatchedItems).toHaveBeenCalled();
 	});
 
+	it('parses p99-logger-client JSONL auction records', async () => {
+		state.watchedItems.BLUE.WTS.knownItems = {
+			'FLOWING BLACK SILK SASH': [1],
+		};
+
+		await handleLogLine(
+			Server.BLUE,
+			p99LoggerRecord({
+				text: 'WTS FBSS 100pp',
+				item_links: [
+					{
+						body: '00002A0000000000000000000000000000000ABCDEF12',
+						text: 'FBSS',
+						start: 4,
+						end: 55,
+						item_id: 42,
+					},
+				],
+			}),
+		);
+
+		expect(streamAuctionToAllStreamChannels).toHaveBeenCalledWith(
+			'Soandso',
+			Server.BLUE,
+			'WTS FBSS 100pp',
+			expect.objectContaining({
+				selling: expect.arrayContaining([
+					expect.objectContaining({ item: 'FBSS', price: 100 }),
+				]),
+			}),
+		);
+		expect(triggerFoundWatchedItems).toHaveBeenCalled();
+	});
+
 	it('routes OOC link lines to handleLinkMatch and not auction handling', async () => {
 		const line = `Soandso says out of character, 'Link me: ${LINK_CODE}'`;
 
@@ -80,6 +133,40 @@ describe('handleLogLine', () => {
 		);
 		expect(streamAuctionToAllStreamChannels).not.toHaveBeenCalled();
 		expect(redis.get).not.toHaveBeenCalled();
+	});
+
+	it('routes p99-logger-client JSONL OOC links', async () => {
+		await handleLogLine(
+			Server.BLUE,
+			p99LoggerRecord({
+				channel: 5,
+				channel_name: 'ooc',
+				text: `Link me: ${LINK_CODE}`,
+			}),
+		);
+
+		expect(handleLinkMatch).toHaveBeenCalledWith(
+			'Soandso',
+			Server.BLUE,
+			LINK_CODE,
+		);
+		expect(streamAuctionToAllStreamChannels).not.toHaveBeenCalled();
+	});
+
+	it('ignores malformed and unrelated JSONL records', async () => {
+		expect(parseLogLine('{bad json')).toBeUndefined();
+		expect(
+			parseLogLine(
+				p99LoggerRecord({ channel: 0, channel_name: 'guild' }),
+			),
+		).toBeUndefined();
+		expect(
+			parseLogLine(p99LoggerRecord({ type: 'decode_error' })),
+		).toBeUndefined();
+
+		await handleLogLine(Server.BLUE, '{bad json');
+		expect(streamAuctionToAllStreamChannels).not.toHaveBeenCalled();
+		expect(handleLinkMatch).not.toHaveBeenCalled();
 	});
 
 	it('does not throw on a malformed partial auction line', async () => {

--- a/src/lib/parser/monitorLogs.ts
+++ b/src/lib/parser/monitorLogs.ts
@@ -48,17 +48,93 @@ export function generateAuctionKey(auctionText: string) {
 
 const parser = new AuctionParser();
 
-export async function handleLogLine(server: Server, data: string) {
-	// filter for log lines that start with "soAndSo auctions,"
-	const auctionMatch = data.match(/(\w+) auctions?, '(.+)'/);
-	const linkMatch = data.match(
-		/(\w+) says? out of character, 'Link me: ([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12})'/,
-	);
+export type ParsedLogLine =
+	| { kind: 'auction'; playerName: string; text: string }
+	| { kind: 'link'; playerName: string; linkCode: string };
 
+type P99LoggerRecord = {
+	type?: unknown;
+	channel_name?: unknown;
+	sender?: unknown;
+	text?: unknown;
+};
+
+const UUID_PATTERN =
+	/[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/
+		.source;
+const LINK_CODE = new RegExp(`^Link me: (${UUID_PATTERN})$`);
+const TEXT_LINK = new RegExp(
+	`(\\w+) says? out of character, 'Link me: (${UUID_PATTERN})'`,
+);
+
+/** Read an auction or player-link request from either supported log format. */
+export function parseLogLine(data: string): ParsedLogLine | undefined {
+	if (data.trimStart().startsWith('{')) {
+		let record: P99LoggerRecord;
+		try {
+			record = JSON.parse(data) as P99LoggerRecord;
+		} catch {
+			return undefined;
+		}
+
+		if (
+			record.type !== 'chat' ||
+			typeof record.sender !== 'string' ||
+			record.sender.length === 0 ||
+			typeof record.text !== 'string'
+		) {
+			return undefined;
+		}
+
+		if (record.channel_name === 'auction') {
+			return {
+				kind: 'auction',
+				playerName: record.sender,
+				text: record.text,
+			};
+		}
+
+		if (record.channel_name === 'ooc') {
+			const match = record.text.match(LINK_CODE);
+			if (match) {
+				return {
+					kind: 'link',
+					playerName: record.sender,
+					linkCode: match[1],
+				};
+			}
+		}
+
+		return undefined;
+	}
+
+	const auctionMatch = data.match(/(\w+) auctions?, '(.+)'/);
 	if (auctionMatch) {
-		debug(`Auction Match: ${auctionMatch}`);
-		// extract the timestamp, player, and auction message from the log line
-		const [, playerName, auctionText] = auctionMatch;
+		return {
+			kind: 'auction',
+			playerName: auctionMatch[1],
+			text: auctionMatch[2],
+		};
+	}
+
+	const linkMatch = data.match(TEXT_LINK);
+	if (linkMatch) {
+		return {
+			kind: 'link',
+			playerName: linkMatch[1],
+			linkCode: linkMatch[2],
+		};
+	}
+
+	return undefined;
+}
+
+export async function handleLogLine(server: Server, data: string) {
+	const parsed = parseLogLine(data);
+
+	if (parsed?.kind === 'auction') {
+		const { playerName, text: auctionText } = parsed;
+		debug(`Auction Match: ${playerName}: ${auctionText}`);
 		const auctionLogKey = generateAuctionKey(auctionText.toUpperCase());
 		const cachedAuctionData = await redis.get(auctionLogKey);
 		let auctionData: AuctionData;
@@ -156,12 +232,9 @@ export async function handleLogLine(server: Server, data: string) {
 				);
 			}
 		}
-	} else if (linkMatch) {
-		debug(`Link Match: ${linkMatch}`);
-		const [, playerName, linkCode] = linkMatch;
-		// console.log(playerName, linkMatch);
-
-		await handleLinkMatch(playerName, server, linkCode);
+	} else if (parsed?.kind === 'link') {
+		debug(`Link Match: ${parsed.playerName}: ${parsed.linkCode}`);
+		await handleLinkMatch(parsed.playerName, server, parsed.linkCode);
 	}
 }
 


### PR DESCRIPTION
TunnelQuestBot currently requires EverQuest text log files, which means Green and Blue collectors need full game clients. This adds an optional `p99-loggers` Compose profile that runs one headless `p99-logger-client` for each server and shares their JSONL output with the bot.

The parser auto-detects logger JSONL records and sends auction messages and OOC player-link requests through the same paths as native EQ log lines. Both formats share the UUID pattern for link requests. Malformed records, decode errors, and unrelated channels are ignored.

The published amd64 logger image is pinned to `sha-fbb036a` and includes the P99 asset checksum inventory. The Green and Blue configuration templates collect only auction and OOC channels. Real credentials and collected logs are excluded from Git and Docker build contexts; TQB ships no asset inventory.

Log-file initialization runs before the bot in every Compose configuration; only the collectors require the `p99-loggers` profile. The legacy log mount defaults to an ignored `./logs` directory, so headless setups need no EverQuest directory. Existing deployments can keep their configured log directory. Collectors use configurable host UID/GID, read-only root filesystems, dropped capabilities, private configuration mounts, and health checks.

Validation:
- formatting, lint, type checks, and compilation passed
- 619 unit tests passed, including native text and JSONL parser coverage
- disposable Compose startup checks passed with the collector profile both enabled and disabled; a deliberately delayed initializer completed before the bot could read its log files
- verified default/unset LOG_SOURCE_PATH and explicit legacy-directory overrides
- GitHub CI runs coverage, integration tests, the production image build, and Compose smoke startup against merged main
