### PR TITLE
Harden long-running collector operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,7 @@ P99_UID=1000
 P99_GID=1000
 # The active JSONL file rotates in place at this size. Rotated copies are
 # compressed, and the collector/bot keep using the same active file path.
+# Size: positive whole number plus k, K, M, or G. Interval: positive seconds.
 P99_JSONL_MAX_SIZE=100M
 P99_JSONL_ROTATE_COUNT=5
 P99_JSONL_ROTATE_INTERVAL_SECONDS=300

--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,15 @@ P99_GREEN_CONFIG_FILE=./p99-logger/green.json
 # Replace these with the output of `id -u` and `id -g` on Linux.
 P99_UID=1000
 P99_GID=1000
+# The active JSONL file rotates in place at this size. Rotated copies are
+# compressed, and the collector/bot keep using the same active file path.
+P99_JSONL_MAX_SIZE=100M
+P99_JSONL_ROTATE_COUNT=5
+P99_JSONL_ROTATE_INTERVAL_SECONDS=300
+
+# Bound stdout/stderr retained by Docker for every Compose service.
+DOCKER_LOG_MAX_SIZE=10m
+DOCKER_LOG_MAX_FILES=5
 
 ####################################
 ### DO NOT TOUCH BELOW THIS LINE ###

--- a/README.md
+++ b/README.md
@@ -127,6 +127,27 @@ The credential files, JSONL logs, and health state are kept out of the bot
 image. The collectors run without capabilities, with read-only root
 filesystems, and use a named volume shared read-only with the bot.
 
+### Log retention
+
+Every Compose service uses Docker's rotating `local` log driver. By default,
+Docker keeps five 10 MB stdout/stderr files per container; override
+`DOCKER_LOG_MAX_SIZE` or `DOCKER_LOG_MAX_FILES` in `.env` if needed. This
+includes all TunnelQuestBot application output.
+
+The `p99-log-retention` sidecar checks the Green and Blue JSONL files every
+five minutes. When an active file exceeds 100 MB, `logrotate` copies and
+truncates it in place, compresses the copy, and retains five archives. Keeping
+the active path and inode stable lets both the collector and TunnelQuestBot
+continue using it without a restart. Configure this with
+`P99_JSONL_MAX_SIZE`, `P99_JSONL_ROTATE_COUNT`, and
+`P99_JSONL_ROTATE_INTERVAL_SECONDS`.
+
+Archives live beside the active file in the private `p99-logger-data` volume
+as files such as `chat.jsonl.1.gz`. As with any `copytruncate` rotation, a line
+written during the brief copy/truncate window can be absent from the archive
+or the bot's tail. The window is short and rotation is infrequent, but this is
+not a lossless archival mechanism.
+
 ## Running In Production
 
 ### Updating to a new version

--- a/README.md
+++ b/README.md
@@ -140,7 +140,11 @@ truncates it in place, compresses the copy, and retains five archives. Keeping
 the active path and inode stable lets both the collector and TunnelQuestBot
 continue using it without a restart. Configure this with
 `P99_JSONL_MAX_SIZE`, `P99_JSONL_ROTATE_COUNT`, and
-`P99_JSONL_ROTATE_INTERVAL_SECONDS`.
+`P99_JSONL_ROTATE_INTERVAL_SECONDS`. The size must be a positive whole number
+followed by `k`, `K`, `M`, or `G` (for example, `100M`); bare byte counts and
+zero sizes are rejected. The interval must be a positive whole number of seconds.
+If a rotation pass fails, the sidecar reports it and retries after that interval
+without restarting or discarding its rotation state.
 
 Archives live beside the active file in the private `p99-logger-data` volume
 as files such as `chat.jsonl.1.gz`. As with any `copytruncate` rotation, a line

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,14 @@
+x-default-logging: &default-logging
+  driver: local
+  options:
+    max-size: "${DOCKER_LOG_MAX_SIZE:-10m}"
+    max-file: "${DOCKER_LOG_MAX_FILES:-5}"
+
 services:
     postgres:
       image: postgres:18-alpine
       container_name: postgres
+      logging: *default-logging
       environment:
         POSTGRES_USER: "${POSTGRES_USER}"
         POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
@@ -22,6 +29,7 @@ services:
     redis:
       image: redis:alpine
       container_name: redis
+      logging: *default-logging
       environment:
         REDIS_CONFIG: |
           unixsocket /var/run/redis/redis.sock
@@ -42,6 +50,7 @@ services:
 
     p99-logger-init:
       image: busybox:1.37.0
+      logging: *default-logging
       environment:
         P99_UID: "${P99_UID:-65534}"
         P99_GID: "${P99_GID:-65534}"
@@ -61,11 +70,14 @@ services:
     p99-green-logger:
       image: "${P99_LOGGER_IMAGE:-ghcr.io/rm-you/p99-logger-client:sha-fbb036a}"
       profiles: ["p99-loggers"]
+      logging: *default-logging
       user: "${P99_UID:-65534}:${P99_GID:-65534}"
       command: ["/config/config.json"]
       depends_on:
         p99-logger-init:
           condition: service_completed_successfully
+        p99-log-retention:
+          condition: service_started
       volumes:
         - type: bind
           source: "${P99_GREEN_CONFIG_FILE:-./p99-logger/green.json}"
@@ -88,11 +100,14 @@ services:
     p99-blue-logger:
       image: "${P99_LOGGER_IMAGE:-ghcr.io/rm-you/p99-logger-client:sha-fbb036a}"
       profiles: ["p99-loggers"]
+      logging: *default-logging
       user: "${P99_UID:-65534}:${P99_GID:-65534}"
       command: ["/config/config.json"]
       depends_on:
         p99-logger-init:
           condition: service_completed_successfully
+        p99-log-retention:
+          condition: service_started
       volumes:
         - type: bind
           source: "${P99_BLUE_CONFIG_FILE:-./p99-logger/blue.json}"
@@ -112,11 +127,35 @@ services:
         retries: 3
         start_period: 60s
 
+    p99-log-retention:
+      build:
+        context: .
+        dockerfile: p99-logger/retention.Dockerfile
+      profiles: ["p99-loggers"]
+      logging: *default-logging
+      user: "${P99_UID:-65534}:${P99_GID:-65534}"
+      environment:
+        P99_JSONL_MAX_SIZE: "${P99_JSONL_MAX_SIZE:-100M}"
+        P99_JSONL_ROTATE_COUNT: "${P99_JSONL_ROTATE_COUNT:-5}"
+        P99_JSONL_ROTATE_INTERVAL_SECONDS: "${P99_JSONL_ROTATE_INTERVAL_SECONDS:-300}"
+      depends_on:
+        p99-logger-init:
+          condition: service_completed_successfully
+      volumes:
+        - p99-logger-data:/data
+      read_only: true
+      tmpfs:
+        - /tmp:mode=1777,size=1m
+      cap_drop: ["ALL"]
+      security_opt: ["no-new-privileges:true"]
+      restart: unless-stopped
+
     tunnelquestbot:
       build:
         context: .
         dockerfile: Dockerfile
       container_name: tunnelquestbot
+      logging: *default-logging
       depends_on:
         postgres:
           condition: service_healthy

--- a/p99-logger/retention-entrypoint.sh
+++ b/p99-logger/retention-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+max_size="${P99_JSONL_MAX_SIZE:-100M}"
+rotate_count="${P99_JSONL_ROTATE_COUNT:-5}"
+interval="${P99_JSONL_ROTATE_INTERVAL_SECONDS:-300}"
+
+case "$max_size" in
+	*[kKmMgG]) size_number="${max_size%?}" ;;
+	*) size_number="$max_size" ;;
+esac
+case "$size_number" in
+	''|*[!0-9]*) echo "P99_JSONL_MAX_SIZE must be a size such as 100M" >&2; exit 1 ;;
+esac
+case "$rotate_count" in
+	''|*[!0-9]*) echo "P99_JSONL_ROTATE_COUNT must be a non-negative integer" >&2; exit 1 ;;
+esac
+case "$interval" in
+	''|*[!0-9]*|0) echo "P99_JSONL_ROTATE_INTERVAL_SECONDS must be a positive integer" >&2; exit 1 ;;
+esac
+
+cat > /tmp/logrotate.conf <<EOF
+/data/green/chat.jsonl /data/blue/chat.jsonl {
+	size $max_size
+	rotate $rotate_count
+	missingok
+	notifempty
+	copytruncate
+	compress
+}
+EOF
+
+echo "JSONL retention active: check every ${interval}s, rotate at ${max_size}, keep ${rotate_count} compressed archives"
+
+while true; do
+	logrotate --state /tmp/logrotate.status /tmp/logrotate.conf
+	sleep "$interval"
+done

--- a/p99-logger/retention-entrypoint.sh
+++ b/p99-logger/retention-entrypoint.sh
@@ -5,19 +5,30 @@ max_size="${P99_JSONL_MAX_SIZE:-100M}"
 rotate_count="${P99_JSONL_ROTATE_COUNT:-5}"
 interval="${P99_JSONL_ROTATE_INTERVAL_SECONDS:-300}"
 
+# Check decimal digits without shell arithmetic or its leading-zero semantics.
+is_positive_integer() {
+	case "$1" in
+		''|*[!0-9]*) return 1 ;;
+		*[1-9]*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
 case "$max_size" in
-	*[kKmMgG]) size_number="${max_size%?}" ;;
-	*) size_number="$max_size" ;;
+	*[kKMG]) size_number="${max_size%?}" ;;
+	*) size_number= ;;
 esac
-case "$size_number" in
-	''|*[!0-9]*) echo "P99_JSONL_MAX_SIZE must be a size such as 100M" >&2; exit 1 ;;
-esac
+if ! is_positive_integer "$size_number"; then
+	echo "P99_JSONL_MAX_SIZE must be a positive integer followed by k, K, M, or G, such as 100M" >&2
+	exit 1
+fi
 case "$rotate_count" in
 	''|*[!0-9]*) echo "P99_JSONL_ROTATE_COUNT must be a non-negative integer" >&2; exit 1 ;;
 esac
-case "$interval" in
-	''|*[!0-9]*|0) echo "P99_JSONL_ROTATE_INTERVAL_SECONDS must be a positive integer" >&2; exit 1 ;;
-esac
+if ! is_positive_integer "$interval"; then
+	echo "P99_JSONL_ROTATE_INTERVAL_SECONDS must be a positive integer" >&2
+	exit 1
+fi
 
 cat > /tmp/logrotate.conf <<EOF
 /data/green/chat.jsonl /data/blue/chat.jsonl {
@@ -33,6 +44,8 @@ EOF
 echo "JSONL retention active: check every ${interval}s, rotate at ${max_size}, keep ${rotate_count} compressed archives"
 
 while true; do
-	logrotate --state /tmp/logrotate.status /tmp/logrotate.conf
+	if ! logrotate --state /tmp/logrotate.status /tmp/logrotate.conf; then
+		echo "rotation pass failed; retrying next interval" >&2
+	fi
 	sleep "$interval"
 done

--- a/p99-logger/retention.Dockerfile
+++ b/p99-logger/retention.Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.22
+
+RUN apk add --no-cache logrotate
+
+COPY p99-logger/retention-entrypoint.sh /usr/local/bin/retention-entrypoint
+
+RUN chmod 755 /usr/local/bin/retention-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/retention-entrypoint"]

--- a/src/lib/helpers/fetchHistoricalPricing.test.ts
+++ b/src/lib/helpers/fetchHistoricalPricing.test.ts
@@ -53,6 +53,7 @@ describe('fetchHistoricalPricingForItem', () => {
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
 	});
 
 	it('returns parsed pricing for a 200 response', async () => {
@@ -95,15 +96,31 @@ describe('fetchHistoricalPricingForItem', () => {
 		consoleError.mockRestore();
 	});
 
-	it('rejects when fetch rejects', async () => {
+	it('returns null when fetch rejects without reporting to Discord', async () => {
+		const consoleWarn = vi
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
 		vi.mocked(fetch).mockRejectedValueOnce(new Error('network down'));
 
 		await expect(
 			fetchHistoricalPricingForItem('FBSS', Server.BLUE),
-		).rejects.toThrow('network down');
+		).resolves.toBeNull();
+
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`Historical pricing unavailable for BLUE/${CANONICAL_FBSS}`,
+			),
+		);
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining('Error: network down'),
+		);
+		expect(gracefullyHandleError).not.toHaveBeenCalled();
 	});
 
-	it('rejects when response JSON is malformed', async () => {
+	it('returns null when response JSON is malformed', async () => {
+		const consoleWarn = vi
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			status: 200,
@@ -114,7 +131,12 @@ describe('fetchHistoricalPricingForItem', () => {
 
 		await expect(
 			fetchHistoricalPricingForItem('FBSS', Server.BLUE),
-		).rejects.toThrow('invalid json');
+		).resolves.toBeNull();
+
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining('Error: invalid json'),
+		);
+		expect(gracefullyHandleError).not.toHaveBeenCalled();
 	});
 
 	it('skips fetch on a cache hit', async () => {

--- a/src/lib/helpers/fetchHistoricalPricing.ts
+++ b/src/lib/helpers/fetchHistoricalPricing.ts
@@ -15,6 +15,20 @@ function getServerIntForExternalApi(server: Server) {
 	return Server[server];
 }
 
+function logUnavailablePricing(
+	server: Server,
+	itemName: string,
+	error: unknown,
+): void {
+	const reason =
+		error instanceof Error
+			? `${error.name}: ${error.message}`
+			: String(error);
+	console.warn(
+		`Historical pricing unavailable for ${server}/${itemName}; continuing without it (${reason})`,
+	);
+}
+
 export async function fetchHistoricalPricingForItem(
 	itemName: string,
 	server: Server,
@@ -29,7 +43,13 @@ export async function fetchHistoricalPricingForItem(
 		}/api/item/get/${getServerIntForExternalApi(
 			server,
 		)}/${encodeURIComponent(pricingItemName)}`;
-		const res = await fetch(endpoint);
+		let res: Response;
+		try {
+			res = await fetch(endpoint);
+		} catch (error) {
+			logUnavailablePricing(server, pricingItemName, error);
+			return null;
+		}
 
 		if (res.status === 204) {
 			return null;
@@ -40,7 +60,12 @@ export async function fetchHistoricalPricingForItem(
 			return null;
 		}
 
-		historicalPrice = await res.json();
+		try {
+			historicalPrice = await res.json();
+		} catch (error) {
+			logUnavailablePricing(server, pricingItemName, error);
+			return null;
+		}
 		await redis.set(
 			key,
 			JSON.stringify(historicalPrice),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -290,6 +290,22 @@ describe('startup migration invariants', () => {
 			/depends_on:\s*\n\s*postgres:\s*\n\s*condition: service_healthy/,
 		);
 	});
+
+	it('bounds container logs and rotates collector JSONL files', () => {
+		const compose = readRepoFile('docker-compose.yml');
+		const retention = readRepoFile('p99-logger/retention-entrypoint.sh');
+
+		expect(compose).toMatch(/driver: local/);
+		expect(compose).toMatch(/DOCKER_LOG_MAX_SIZE:-10m/);
+		expect(compose).toMatch(/DOCKER_LOG_MAX_FILES:-5/);
+		expect(compose).toMatch(/p99-log-retention:/);
+		expect(compose).toMatch(/P99_JSONL_MAX_SIZE:-100M/);
+		expect(retention).toMatch(/copytruncate/);
+		expect(retention).toMatch(/compress/);
+		expect(retention).toMatch(
+			/\/data\/green\/chat\.jsonl \/data\/blue\/chat\.jsonl/,
+		);
+	});
 });
 
 //	These two guard the first-run path: a contributor copies .env.example, fills

--- a/test/retention.test.ts
+++ b/test/retention.test.ts
@@ -1,0 +1,155 @@
+import { spawnSync } from 'child_process';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+// Relocate only the temporary files; execute the actual entrypoint with bounded
+// command stand-ins so validation and retry behavior run without Docker or logs.
+function runRetention(env: Record<string, string> = {}, failFirst = false) {
+	const directory = mkdtempSync(join(tmpdir(), 'tqb-retention-'));
+	try {
+		const script = join(directory, 'entrypoint.sh');
+		const source = readFileSync(
+			'p99-logger/retention-entrypoint.sh',
+			'utf8',
+		);
+		writeFileSync(
+			script,
+			source.replaceAll('/tmp/logrotate.', '"$RETENTION_TMP"/logrotate.'),
+		);
+		const trace = join(directory, 'trace');
+		const config = join(directory, 'logrotate.conf');
+		const result = spawnSync(
+			'sh',
+			[
+				'-c',
+				`passes=0
+logrotate() {
+  passes=$((passes + 1))
+  echo "rotate:$passes" >> "$TRACE"
+  if [ "$passes" -eq 1 ]; then
+    echo retained-state > "$2"
+    [ "$FAIL_FIRST" != true ]
+  else
+    echo "state:$(cat "$2")" >> "$TRACE"
+  fi
+}
+sleep() {
+  echo "sleep:$1" >> "$TRACE"
+  [ "$passes" -lt 2 ] || exit 77
+}
+. "$1"`,
+				'sh',
+				script,
+			],
+			{
+				env: {
+					...process.env,
+					P99_JSONL_MAX_SIZE: '',
+					P99_JSONL_ROTATE_COUNT: '',
+					P99_JSONL_ROTATE_INTERVAL_SECONDS: '',
+					...env,
+					RETENTION_TMP: directory,
+					TRACE: trace,
+					FAIL_FIRST: String(failFirst),
+				},
+				encoding: 'utf8',
+				timeout: 5000,
+			},
+		);
+		expect(result.error).toBeUndefined();
+		return {
+			status: result.status,
+			stderr: result.stderr,
+			trace: existsSync(trace)
+				? readFileSync(trace, 'utf8').trim().split('\n')
+				: [],
+			config: existsSync(config) ? readFileSync(config, 'utf8') : '',
+		};
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+describe.skipIf(process.platform === 'win32')(
+	'JSONL retention entrypoint',
+	() => {
+		it('keeps the shipped defaults and sleeps between rotation passes', () => {
+			const result = runRetention();
+			expect(result.status).toBe(77);
+			expect(result.stderr).toBe('');
+			expect(result.config).toContain('size 100M');
+			expect(result.config).toContain('rotate 5');
+			expect(result.trace).toEqual([
+				'rotate:1',
+				'sleep:300',
+				'rotate:2',
+				'state:retained-state',
+				'sleep:300',
+			]);
+		});
+
+		it.each(['0', '00', '000', '-1', '1.5', 'abc'])(
+			'rejects interval %s before touching rotation files',
+			(interval) => {
+				const result = runRetention({
+					P99_JSONL_ROTATE_INTERVAL_SECONDS: interval,
+				});
+				expect(result.status).toBe(1);
+				expect(result.stderr).toContain(
+					'P99_JSONL_ROTATE_INTERVAL_SECONDS',
+				);
+				expect(result.trace).toEqual([]);
+				expect(result.config).toBe('');
+			},
+		);
+
+		it.each(['100', '0', '0M', '00M', '1.5M', '-1M', 'M', '1m', '1g'])(
+			'rejects invalid size %s before touching rotation files',
+			(size) => {
+				const result = runRetention({ P99_JSONL_MAX_SIZE: size });
+				expect(result.status).toBe(1);
+				expect(result.stderr).toContain('P99_JSONL_MAX_SIZE');
+				expect(result.trace).toEqual([]);
+				expect(result.config).toBe('');
+			},
+		);
+
+		it.each(['1k', '1K', '001M', '2G'])(
+			'accepts size %s and a positive zero-padded interval',
+			(size) => {
+				const result = runRetention({
+					P99_JSONL_MAX_SIZE: size,
+					P99_JSONL_ROTATE_INTERVAL_SECONDS: '0300',
+					P99_JSONL_ROTATE_COUNT: '0',
+				});
+				expect(result.status).toBe(77);
+				expect(result.config).toContain(`size ${size}`);
+				expect(result.config).toContain('rotate 0');
+				expect(result.trace).toContain('sleep:0300');
+			},
+		);
+
+		it('reports a failed pass, waits, and retries with the same state', () => {
+			const result = runRetention({}, true);
+			expect(result.status).toBe(77);
+			expect(result.stderr).toContain(
+				'rotation pass failed; retrying next interval',
+			);
+			expect(result.trace).toEqual([
+				'rotate:1',
+				'sleep:300',
+				'rotate:2',
+				'state:retained-state',
+				'sleep:300',
+			]);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

- Cap Docker stdout/stderr with the rotating `local` driver.
- Rotate Green/Blue JSONL files with a non-root logrotate sidecar.
- Require positive rotation sizes with an explicit unit and positive check intervals, including validation of zero-padded values.
- Report failed rotation passes and retry after the normal interval while preserving rotation state.
- Treat historical pricing network/JSON failures as optional enrichment, keeping auction streams running without Discord error reports when PigParse is unavailable.

## Defaults

- Docker logs: 5 files × 10 MB per container.
- JSONL: rotate at 100 MB, retain 5 compressed archives, check every 5 minutes.

## Validation

- Formatting, lint, type checks, coverage thresholds, and build passed on Node 24/Linux.
- Full unit suite: 641 passed, including 21 process-level retention tests.
- The new tests reproduced the validation and retry defects before the fix.
- Updated retention image built successfully; an isolated non-root container with synthetic logs verified actual copytruncate/compression, accepted size units, rejection of invalid settings, and recovery with preserved state after a simulated rotation failure.

PR #123 is stacked on this branch.
