### PR TITLE
fix(watch): make /watches filter case-insensitive

### DIFF
--- a/src/prisma/dbExecutors/watch.itest.ts
+++ b/src/prisma/dbExecutors/watch.itest.ts
@@ -204,6 +204,21 @@ describe('watch dbExecutor (integration)', () => {
 			expect(await getWatchesByItemName('100', '')).toHaveLength(2);
 		});
 
+		it('getWatchesByItemName filters case-insensitively', async () => {
+			const { upsertWatch, getWatchesByItemName } = await import(
+				'./watch'
+			);
+			await seedUser();
+
+			await upsertWatch('100', {
+				...defaultWatchData,
+				itemName: 'MAGIC SWORD',
+			});
+
+			expect(await getWatchesByItemName('100', 'sword')).toHaveLength(1);
+			expect(await getWatchesByItemName('100', 'Sword')).toHaveLength(1);
+		});
+
 		it('getWatchByWatchId throws when the watch is missing', async () => {
 			const { getWatchByWatchId } = await import('./watch');
 

--- a/src/prisma/dbExecutors/watch.ts
+++ b/src/prisma/dbExecutors/watch.ts
@@ -141,7 +141,7 @@ export async function getWatchesByItemName(
 ) {
 	const watches = await getWatchesByUser(discordUserId);
 	return watches.filter((watch) => {
-		return watch.itemName.includes(itemName);
+		return watch.itemName.includes(itemName.toUpperCase());
 	});
 }
 


### PR DESCRIPTION
`getWatchesByItemName` compared the raw user-typed `filter` value against `watch.itemName`, which is always stored uppercase (see `normalizeStoredWatchItemName`). Anything other than an all-caps filter (e.g. `/watches filter:sword`) silently matched nothing, even when a matching watch existed.

The sibling function `getPlayerBlocks` already handles this correctly by uppercasing the filter before comparing. This applies the same fix to `getWatchesByItemName`.

## Changes
- `src/prisma/dbExecutors/watch.ts`: uppercase `itemName` filter before `.includes()`
- `src/prisma/dbExecutors/watch.itest.ts`: add a case-insensitivity regression test

## Testing
Added an integration test asserting `getWatchesByItemName('100', 'sword')` and `getWatchesByItemName('100', 'Sword')` both match a watch stored as `MAGIC SWORD`. Not run locally — this repo's `test:integration` needs Docker + Node 24, unavailable in the review environment; the new test follows the exact pattern of the existing adjacent case in the same file.