### PR TITLE
Add guarded SQLite cutover tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 # But not these files...
 !.gitignore
 !*.bat
+!*.ps1
 !*.yml
+!README.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 !*.ps1
 !*.yml
 !README.md
+!/tests/

--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@ PostgreSQL. Use the migration script for the first SQLite deployment. It:
 3. asks for confirmation before stopping the bot;
 4. saves the original `.env`, then creates and validates a PostgreSQL dump
    under `%USERPROFILE%\TunnelQuestBot-backups`;
-5. independently compares all five PostgreSQL and SQLite table counts and
-   verifies SQLite foreign keys and integrity before changing `.env`;
-6. restarts the bot on the persistent `sqlite-data` volume; and
-7. stops PostgreSQL while retaining its container, volume and dump for rollback.
+5. runs migrations and the importer in a one-shot container while the bot stays
+   stopped, then independently compares all five table counts and verifies
+   SQLite foreign keys, integrity and the import marker;
+6. stops PostgreSQL, retaining its container, volume and dump for rollback;
+7. changes `.env` and starts the bot on the persistent `sqlite-data` volume; and
+8. checks startup stability and SQLite integrity without comparing live row
+   counts to the old PostgreSQL snapshot.
 
 The script supports Windows PowerShell 5.1 and current Docker Desktop Compose.
 If it fails after stopping the bot, it leaves the bot stopped and preserves the
-source data. If it had already changed `.env` or stopped PostgreSQL, it restores
-the original `.env` and restarts PostgreSQL so the cutover can be retried.
+source data. Before SQLite startup is attempted, it restores the original `.env`
+and restarts PostgreSQL if needed so the cutover can be retried. After startup
+is attempted, SQLite may contain new writes: the script keeps SQLite configured
+and leaves the bot stopped for repair. Fix the startup problem and use `start.bat`;
+do not rerun the import or switch databases without reconciling those writes.
 
 Both backup files contain private deployment data and must remain access
 controlled. For a full rollback, stop the SQLite bot, restore the pre-cutover
@@ -47,3 +53,11 @@ back to PostgreSQL.
 - `clear_auction_data_from_redis.bat` clears cached parsed auctions.
 
 Never run `docker compose down -v`; it deletes persistent database volumes.
+
+## Testing the cutover scripts
+
+Run `powershell -NoProfile -ExecutionPolicy Bypass -File tests\cutover.Tests.ps1` with Windows PowerShell
+5.1. The tests use temporary synthetic configuration and a Docker stand-in;
+they do not connect to Docker or modify a deployment. They cover offline import
+ordering, live additions/deletions, pre-activation failures, post-activation
+recovery and the startup configuration guard.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# TunnelQuestBot production deployment
+
+This branch contains only the files used by the Windows production host. It
+runs the promoted `prod/tunnelquestbot:latest` image and keeps configuration in
+the host's untracked `.env`.
+
+## One-time PostgreSQL to SQLite upgrade
+
+Promote an application image that includes SQLite support before starting the
+cutover. Update this branch on the deployment host, then run:
+
+```bat
+migrate-postgres-to-sqlite.bat
+```
+
+Do not use `update.bat` for the first SQLite deployment. The migration script:
+
+1. pulls the promoted image and verifies that it contains the importer;
+2. reads the source credentials from the existing PostgreSQL container without
+   printing them;
+3. asks for confirmation before stopping the bot;
+4. creates and validates a private PostgreSQL dump under
+   `%USERPROFILE%\TunnelQuestBot-backups`;
+5. imports and verifies SQLite before changing `.env`;
+6. restarts the bot on the persistent `sqlite-data` volume; and
+7. stops PostgreSQL while retaining its container, volume and dump for rollback.
+
+The script supports Windows PowerShell 5.1 and current Docker Desktop Compose.
+If it fails after stopping the bot, it leaves the bot stopped and preserves the
+source data. Resolve the reported error before retrying or rolling back.
+
+## Routine operation
+
+- `start.bat` starts the existing deployment.
+- `stop.bat` stops services without deleting containers or volumes.
+- `update.bat` pulls the promoted image and recreates services as needed.
+- `clear_auction_data_from_redis.bat` clears cached parsed auctions.
+
+Never run `docker compose down -v`; it deletes persistent database volumes.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,31 @@ cutover. Update this branch on the deployment host, then run:
 migrate-postgres-to-sqlite.bat
 ```
 
-Do not use `update.bat` for the first SQLite deployment. The migration script:
+`start.bat` and `update.bat` refuse to run while `.env` still points to
+PostgreSQL. Use the migration script for the first SQLite deployment. It:
 
 1. pulls the promoted image and verifies that it contains the importer;
 2. reads the source credentials from the existing PostgreSQL container without
    printing them;
 3. asks for confirmation before stopping the bot;
-4. creates and validates a private PostgreSQL dump under
-   `%USERPROFILE%\TunnelQuestBot-backups`;
-5. imports and verifies SQLite before changing `.env`;
+4. saves the original `.env`, then creates and validates a PostgreSQL dump
+   under `%USERPROFILE%\TunnelQuestBot-backups`;
+5. independently compares all five PostgreSQL and SQLite table counts and
+   verifies SQLite foreign keys and integrity before changing `.env`;
 6. restarts the bot on the persistent `sqlite-data` volume; and
 7. stops PostgreSQL while retaining its container, volume and dump for rollback.
 
 The script supports Windows PowerShell 5.1 and current Docker Desktop Compose.
 If it fails after stopping the bot, it leaves the bot stopped and preserves the
-source data. Resolve the reported error before retrying or rolling back.
+source data. If it had already changed `.env` or stopped PostgreSQL, it restores
+the original `.env` and restarts PostgreSQL so the cutover can be retried.
+
+Both backup files contain private deployment data and must remain access
+controlled. For a full rollback, stop the SQLite bot, restore the pre-cutover
+`run` revision and the saved `.env`, and start that revision against the retained
+PostgreSQL volume. Do not return users to the old bot until any post-cutover
+changes have been reconciled; the importer does not synchronize SQLite changes
+back to PostgreSQL.
 
 ## Routine operation
 

--- a/assert-sqlite-ready.ps1
+++ b/assert-sqlite-ready.ps1
@@ -9,17 +9,17 @@ try {
         throw 'Missing .env in the deployment directory'
     }
     $envText = [IO.File]::ReadAllText((Resolve-Path '.env'))
-    $matches = [regex]::Matches(
+    $databaseMatches = [regex]::Matches(
         $envText,
         '(?m)^(?!\s*#)\s*DATABASE_URL\s*=\s*(.+?)\s*$'
     )
-    if ($matches.Count -ne 1) {
-        throw "Expected exactly one active DATABASE_URL in .env; found $($matches.Count)"
+    if ($databaseMatches.Count -ne 1) {
+        throw "Expected exactly one active DATABASE_URL in .env; found $($databaseMatches.Count)"
     }
-    if ($matches[0].Groups[1].Value -match '^\s*[''"]?postgres(?:ql)?:') {
+    if ($databaseMatches[0].Groups[1].Value -match '^\s*[''"]?postgres(?:ql)?:') {
         throw 'PostgreSQL cutover is pending. Run migrate-postgres-to-sqlite.bat instead.'
     }
-    if ($matches[0].Groups[1].Value -notmatch '^\s*[''"]?file:') {
+    if ($databaseMatches[0].Groups[1].Value -notmatch '^\s*[''"]?file:') {
         throw 'DATABASE_URL must be a persistent SQLite file URL'
     }
 } catch {

--- a/assert-sqlite-ready.ps1
+++ b/assert-sqlite-ready.ps1
@@ -1,0 +1,28 @@
+#requires -Version 5.1
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+try {
+    if (-not (Test-Path '.env')) {
+        throw 'Missing .env in the deployment directory'
+    }
+    $envText = [IO.File]::ReadAllText((Resolve-Path '.env'))
+    $matches = [regex]::Matches(
+        $envText,
+        '(?m)^(?!\s*#)\s*DATABASE_URL\s*=\s*(.+?)\s*$'
+    )
+    if ($matches.Count -ne 1) {
+        throw "Expected exactly one active DATABASE_URL in .env; found $($matches.Count)"
+    }
+    if ($matches[0].Groups[1].Value -match '^\s*[''"]?postgres(?:ql)?:') {
+        throw 'PostgreSQL cutover is pending. Run migrate-postgres-to-sqlite.bat instead.'
+    }
+    if ($matches[0].Groups[1].Value -notmatch '^\s*[''"]?file:') {
+        throw 'DATABASE_URL must be a persistent SQLite file URL'
+    }
+} catch {
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/clear_auction_data_from_redis.bat
+++ b/clear_auction_data_from_redis.bat
@@ -1,8 +1,6 @@
 @echo off
-REM Setting the Redis container name
-SET REDIS_CONTAINER=redis
-
-REM Deleting keys with a specific prefix in Redis
-docker exec %REDIS_CONTAINER% sh -c "redis-cli --scan --pattern 'auctionLog*' | while read key; do redis-cli DEL \"$key\"; done"
-
+setlocal
+cd /d "%~dp0"
+docker compose exec -T redis sh -ec "redis-cli --scan --pattern 'auctionLog*' | while IFS= read -r key; do redis-cli DEL \"$key\" > /dev/null; done"
+if errorlevel 1 exit /b %errorlevel%
 echo Parsed Auction Data cleared from Redis cache

--- a/docker-compose.postgres-migration.yml
+++ b/docker-compose.postgres-migration.yml
@@ -1,0 +1,38 @@
+# One-time PostgreSQL to SQLite upgrade only.
+# Run migrate-postgres-to-sqlite.bat instead of invoking this file directly.
+services:
+  postgres:
+    image: postgres:18-alpine
+    container_name: postgres
+    logging:
+      driver: local
+      options:
+        max-size: "${DOCKER_LOG_MAX_SIZE:-10m}"
+        max-file: "${DOCKER_LOG_MAX_FILES:-5}"
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "${POSTGRES_DB}"
+    volumes:
+      - postgres18-data:/var/lib/postgresql
+      - db-socket:/var/run/postgresql
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+
+  tunnelquestbot:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_MIGRATION_URL: "${POSTGRES_MIGRATION_URL:?Run migrate-postgres-to-sqlite.bat}"
+    volumes:
+      - "db-socket:${DB_SOCKET_DIR:-/dbsocket}"
+
+volumes:
+  postgres18-data:
+  db-socket:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,14 @@
-version: "3.9"
-services:
-  postgres:
-    image: postgres:18-alpine
-    container_name: postgres
-    environment:
-      POSTGRES_USER: "${POSTGRES_USER}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
-      POSTGRES_DB: "${POSTGRES_DB}"
-    volumes:
-      - postgres18-data:/var/lib/postgresql
-      - db-socket:/var/run/postgresql
-    restart: unless-stopped
+x-default-logging: &default-logging
+  driver: local
+  options:
+    max-size: "${DOCKER_LOG_MAX_SIZE:-10m}"
+    max-file: "${DOCKER_LOG_MAX_FILES:-5}"
 
+services:
   redis:
     image: redis:alpine
     container_name: redis
+    logging: *default-logging
     environment:
       REDIS_CONFIG: |
         unixsocket /var/run/redis/redis.sock
@@ -25,19 +19,29 @@ services:
       - redis-data:/data
       - redis-socket:/var/run/redis
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "-s", "/var/run/redis/redis.sock", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   tunnelquestbot:
     image: ghcr.io/jamesjamail/tunnelquestbot/prod/tunnelquestbot:latest
     container_name: tunnelquestbot
+    logging: *default-logging
     depends_on:
-      - postgres
-      - redis
+      redis:
+        condition: service_healthy
     environment:
+      DATABASE_URL: "${SQLITE_DATABASE_URL:-file:/data/tunnelquestbot.db}"
+      POSTGRES_MIGRATION_URL: "${POSTGRES_MIGRATION_URL:-}"
       SERVERS_BLUE_LOG_FILE_PATH: "/logfiles/${SERVERS_BLUE_LOG_FILE}"
       SERVERS_GREEN_LOG_FILE_PATH: "/logfiles/${SERVERS_GREEN_LOG_FILE}"
       SERVERS_RED_LOG_FILE_PATH: "/logfiles/${SERVERS_RED_LOG_FILE}"
       REDIS_SOCKET_DIR: "${REDIS_SOCKET_DIR}"
       FAKE_LOGS: "${FAKE_LOGS:-false}"
+      DEBUG_MODE: "${DEBUG_MODE:-false}"
     volumes:
       - type: bind
         source: "${LOG_SOURCE_PATH}"
@@ -45,12 +49,11 @@ services:
       - type: bind
         source: ".env"
         target: /app/.env
-      - "db-socket:${DB_SOCKET_DIR}"
+      - sqlite-data:/data
       - "redis-socket:${REDIS_SOCKET_DIR}"
     restart: always
 
 volumes:
-  postgres18-data:
-  db-socket:
+  sqlite-data:
   redis-socket:
   redis-data:

--- a/migrate-postgres-to-sqlite.bat
+++ b/migrate-postgres-to-sqlite.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0migrate-postgres-to-sqlite.ps1" %*
+exit /b %errorlevel%

--- a/migrate-postgres-to-sqlite.ps1
+++ b/migrate-postgres-to-sqlite.ps1
@@ -20,6 +20,7 @@ $environmentBackupPath = $null
 $temporaryEnv = $null
 $environmentSwitched = $false
 $postgresStopped = $false
+$sqliteActivated = $false
 
 function Assert-LastExitCode([string]$Action) {
     if ($LASTEXITCODE -ne 0) {
@@ -37,23 +38,6 @@ function Wait-ForPostgres {
         Start-Sleep -Seconds 2
     }
     throw 'PostgreSQL did not become healthy within two minutes'
-}
-
-function Wait-ForImport {
-    $deadline = (Get-Date).AddMinutes(2)
-    while ((Get-Date) -lt $deadline) {
-        $logs = (docker logs tunnelquestbot 2>&1 | Out-String)
-        if ($logs -match '\[database\] PostgreSQL import (complete|already completed)') {
-            return
-        }
-        if ($logs -match '\[database\] PostgreSQL import failed') {
-            docker logs --tail 100 tunnelquestbot
-            throw 'The PostgreSQL import failed; no partial import was committed'
-        }
-        Start-Sleep -Seconds 2
-    }
-    docker logs --tail 100 tunnelquestbot
-    throw 'The PostgreSQL import did not finish within two minutes'
 }
 
 function Get-PostgresCounts([hashtable]$PostgresEnvironment) {
@@ -103,7 +87,12 @@ db.close();
 console.log(JSON.stringify({ counts, marker, foreignKeyFailures, integrity }));
 if (marker !== 1 || foreignKeyFailures !== 0 || integrity !== 'ok') process.exit(1);
 '@
-    $output = ($verification | docker exec -i tunnelquestbot node | Out-String).Trim()
+    # Use the persistent volume without starting the bot or its dependencies.
+    $output = (
+        $verification |
+            docker compose run --rm --no-deps -T --entrypoint node tunnelquestbot |
+            Out-String
+    ).Trim()
     Assert-LastExitCode 'SQLite verification'
     try {
         $state = $output | ConvertFrom-Json
@@ -153,7 +142,7 @@ try {
     Assert-LastExitCode 'Compose configuration'
     $botImage = ($configText | ConvertFrom-Json).services.tunnelquestbot.image
     docker run --rm --entrypoint sh $botImage -ec `
-        'test -f /app/build/prisma/import-postgres.js && test -d /app/prisma/migrations'
+        'test -f /app/build/prisma/import-postgres.js && test -f /app/prisma.config.ts && test -d /app/src/prisma/migrations'
     Assert-LastExitCode 'SQLite migration support check in the production image'
 
     $postgresJson = (docker inspect postgres 2>$null | Out-String)
@@ -226,9 +215,11 @@ try {
     Write-Host "Validated PostgreSQL backup: $backupPath ($($backup.Length) bytes)"
     $postgresCounts = Get-PostgresCounts $postgresEnvironment
 
-    docker compose @migrationCompose up -d --force-recreate tunnelquestbot
-    Assert-LastExitCode 'Migration bot startup'
-    Wait-ForImport
+    # Import in a one-shot container. The service stays stopped until independent
+    # count and integrity checks succeed, so Discord commands cannot race them.
+    docker compose @migrationCompose run --rm --no-deps -T --entrypoint sh tunnelquestbot -ec `
+        './node_modules/.bin/prisma migrate deploy && node ./build/prisma/import-postgres.js'
+    Assert-LastExitCode 'PostgreSQL import'
     $sqliteState = Test-SqliteImport
     Compare-RowCounts $postgresCounts $sqliteState.counts
 
@@ -255,6 +246,9 @@ try {
 
     Remove-Item Env:POSTGRES_MIGRATION_URL
     $sourceVariableSet = $false
+    # Once startup is attempted, SQLite may receive writes even if Compose fails.
+    # Recovery must keep SQLite selected instead of restoring the old database.
+    $sqliteActivated = $true
     docker compose up -d --force-recreate tunnelquestbot
     Assert-LastExitCode 'SQLite bot startup'
     Start-Sleep -Seconds 10
@@ -267,8 +261,9 @@ try {
         docker logs --tail 100 tunnelquestbot
         throw "The SQLite bot is not stable (status=$botState, restarts=$restartCount)"
     }
-    $sqliteState = Test-SqliteImport
-    Compare-RowCounts $postgresCounts $sqliteState.counts
+    # Live traffic can legitimately add or delete rows after activation.
+    # Verify integrity and the marker here; strict reconciliation was offline.
+    $null = Test-SqliteImport
     docker compose ps
     Assert-LastExitCode 'Final service status'
 
@@ -285,7 +280,7 @@ try {
     Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
     if ($botStopped) {
         docker stop tunnelquestbot 2>$null | Out-Null
-        if ($environmentSwitched) {
+        if ($environmentSwitched -and -not $sqliteActivated) {
             try {
                 $temporaryEnv = "$envPath.sqlite-cutover-restore.tmp"
                 $restoreEncoding = New-Object Text.UTF8Encoding($false)
@@ -297,7 +292,7 @@ try {
                 Write-Host "WARNING: Could not restore .env automatically: $($_.Exception.Message)" -ForegroundColor Yellow
             }
         }
-        if ($postgresStopped) {
+        if ($postgresStopped -and -not $sqliteActivated) {
             docker start postgres 2>$null | Out-Null
             if ($LASTEXITCODE -eq 0) {
                 Write-Host 'Restarted the retained PostgreSQL container.'
@@ -306,7 +301,12 @@ try {
             }
         }
         Write-Host 'The bot was left stopped. PostgreSQL data and any completed backup were retained.'
-        Write-Host 'Correct the reported problem before retrying or follow the rollback procedure.'
+        if ($sqliteActivated) {
+            Write-Host 'SQLite remains configured because it may contain new writes. Repair the startup problem and use start.bat.'
+            Write-Host 'Do not rerun the import or switch back to PostgreSQL without reconciling post-cutover changes.'
+        } else {
+            Write-Host 'Correct the reported problem before retrying or follow the rollback procedure.'
+        }
     }
     exit 1
 } finally {

--- a/migrate-postgres-to-sqlite.ps1
+++ b/migrate-postgres-to-sqlite.ps1
@@ -1,0 +1,240 @@
+#requires -Version 5.1
+
+param(
+    [switch]$Force,
+    [string]$BackupDirectory = (Join-Path $env:USERPROFILE 'TunnelQuestBot-backups')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+$migrationCompose = @(
+    '-f', 'docker-compose.yml',
+    '-f', 'docker-compose.postgres-migration.yml'
+)
+$sourceVariableSet = $false
+$botStopped = $false
+$backupPath = $null
+$temporaryEnv = $null
+
+function Assert-LastExitCode([string]$Action) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Action failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Wait-ForPostgres {
+    $deadline = (Get-Date).AddMinutes(2)
+    while ((Get-Date) -lt $deadline) {
+        $health = docker inspect postgres --format '{{.State.Health.Status}}' 2>$null
+        if ($LASTEXITCODE -eq 0 -and $health.Trim() -eq 'healthy') {
+            return
+        }
+        Start-Sleep -Seconds 2
+    }
+    throw 'PostgreSQL did not become healthy within two minutes'
+}
+
+function Wait-ForImport {
+    $deadline = (Get-Date).AddMinutes(2)
+    while ((Get-Date) -lt $deadline) {
+        $logs = (docker logs tunnelquestbot 2>&1 | Out-String)
+        if ($logs -match '\[database\] PostgreSQL import (complete|already completed)') {
+            return
+        }
+        if ($logs -match '\[database\] PostgreSQL import failed') {
+            docker logs --tail 100 tunnelquestbot
+            throw 'The PostgreSQL import failed; no partial import was committed'
+        }
+        Start-Sleep -Seconds 2
+    }
+    docker logs --tail 100 tunnelquestbot
+    throw 'The PostgreSQL import did not finish within two minutes'
+}
+
+function Test-SqliteImport {
+    $verification = @'
+const Database = require('better-sqlite3');
+const db = new Database('/data/tunnelquestbot.db', { readonly: true });
+const tables = ['User', 'Watch', 'BlockedPlayer', 'BlockedPlayerByWatch', 'PlayerLink'];
+const counts = Object.fromEntries(
+  tables.map((table) => [
+    table,
+    db.prepare(`SELECT count(*) AS count FROM [${table}]`).get().count,
+  ]),
+);
+const marker = db
+  .prepare('SELECT count(*) AS count FROM DataMigration WHERE name = ?')
+  .get('postgres-to-sqlite-v1').count;
+const foreignKeyFailures = db.pragma('foreign_key_check').length;
+const integrity = db.pragma('quick_check', { simple: true });
+db.close();
+console.log(JSON.stringify({ counts, marker, foreignKeyFailures, integrity }));
+if (marker !== 1 || foreignKeyFailures !== 0 || integrity !== 'ok') process.exit(1);
+'@
+    $verification | docker exec -i tunnelquestbot node
+    Assert-LastExitCode 'SQLite verification'
+}
+
+try {
+    if (-not (Test-Path '.env')) {
+        throw 'Missing .env in the deployment directory'
+    }
+
+    docker compose version | Out-Host
+    Assert-LastExitCode 'Docker Compose preflight'
+
+    $envPath = (Resolve-Path '.env').Path
+    $envText = [IO.File]::ReadAllText($envPath)
+    $databaseMatches = [regex]::Matches(
+        $envText,
+        '(?m)^(?!\s*#)\s*DATABASE_URL\s*=\s*(.+?)\s*$'
+    )
+    if ($databaseMatches.Count -ne 1) {
+        throw "Expected exactly one active DATABASE_URL in .env; found $($databaseMatches.Count)"
+    }
+    if ($databaseMatches[0].Groups[1].Value -notmatch '^\s*[''"]?postgres(?:ql)?:') {
+        throw 'DATABASE_URL is not PostgreSQL; this one-time cutover is not applicable'
+    }
+
+    Write-Host 'Pulling and validating the promoted production image...'
+    docker compose pull tunnelquestbot
+    Assert-LastExitCode 'Production image pull'
+    $configText = (docker compose config --format json | Out-String)
+    Assert-LastExitCode 'Compose configuration'
+    $botImage = ($configText | ConvertFrom-Json).services.tunnelquestbot.image
+    docker run --rm --entrypoint sh $botImage -ec `
+        'test -f /app/build/prisma/import-postgres.js && test -d /app/prisma/migrations'
+    Assert-LastExitCode 'SQLite migration support check in the production image'
+
+    $postgresJson = (docker inspect postgres 2>$null | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        throw 'The existing postgres container was not found; restore the old deployment before migrating'
+    }
+    $postgres = ($postgresJson | ConvertFrom-Json)[0]
+    $postgresEnvironment = @{}
+    foreach ($entry in $postgres.Config.Env) {
+        $parts = $entry -split '=', 2
+        $postgresEnvironment[$parts[0]] = $parts[1]
+    }
+    foreach ($name in @('POSTGRES_USER', 'POSTGRES_PASSWORD', 'POSTGRES_DB')) {
+        if (-not $postgresEnvironment.ContainsKey($name) -or
+            [string]::IsNullOrWhiteSpace($postgresEnvironment[$name])) {
+            throw "The existing postgres container has no $name value"
+        }
+    }
+
+    $user = [Uri]::EscapeDataString($postgresEnvironment.POSTGRES_USER)
+    $password = [Uri]::EscapeDataString($postgresEnvironment.POSTGRES_PASSWORD)
+    $database = [Uri]::EscapeDataString($postgresEnvironment.POSTGRES_DB)
+    $env:POSTGRES_MIGRATION_URL = "postgresql://${user}:${password}@postgres/${database}"
+    $sourceVariableSet = $true
+
+    docker compose @migrationCompose config --quiet
+    Assert-LastExitCode 'Migration Compose configuration'
+
+    Write-Host ''
+    Write-Host 'Ready to perform the one-time PostgreSQL to SQLite cutover.'
+    Write-Host 'The bot will be stopped, backed up, imported, verified, and restarted.'
+    Write-Host "The PostgreSQL volume will be retained. Backups: $BackupDirectory"
+    if (-not $Force) {
+        $answer = Read-Host 'Type MIGRATE to continue'
+        if ($answer -cne 'MIGRATE') {
+            throw 'Cutover cancelled; no application data was changed'
+        }
+    }
+
+    docker compose @migrationCompose stop tunnelquestbot
+    Assert-LastExitCode 'Bot shutdown'
+    $botStopped = $true
+
+    docker compose @migrationCompose up -d postgres
+    Assert-LastExitCode 'PostgreSQL startup'
+    Wait-ForPostgres
+
+    New-Item -ItemType Directory -Force -Path $BackupDirectory | Out-Null
+    $stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
+    $backupPath = Join-Path $BackupDirectory "tqb-before-sqlite-$stamp.sql"
+    $containerBackup = '/tmp/tqb-before-sqlite.sql'
+    docker exec postgres sh -ec `
+        'umask 077; pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /tmp/tqb-before-sqlite.sql'
+    Assert-LastExitCode 'PostgreSQL backup'
+    docker cp "postgres:$containerBackup" $backupPath
+    Assert-LastExitCode 'Backup copy'
+    docker exec postgres rm -f $containerBackup
+    Assert-LastExitCode 'Temporary backup cleanup'
+
+    $backup = Get-Item $backupPath
+    $dumpComplete = [bool](
+        Select-String -Path $backupPath -Pattern '^-- PostgreSQL database dump complete$' -Quiet
+    )
+    if ($backup.Length -lt 1024 -or -not $dumpComplete) {
+        throw 'The PostgreSQL dump did not pass validation'
+    }
+    Write-Host "Validated PostgreSQL backup: $backupPath ($($backup.Length) bytes)"
+
+    docker compose @migrationCompose up -d --no-deps --force-recreate tunnelquestbot
+    Assert-LastExitCode 'Migration bot startup'
+    Wait-ForImport
+    Test-SqliteImport
+
+    docker compose @migrationCompose stop postgres
+    Assert-LastExitCode 'PostgreSQL shutdown'
+
+    $updatedEnv = [regex]::Replace(
+        $envText,
+        '(?m)^(?!\s*#)\s*DATABASE_URL\s*=.*$',
+        'DATABASE_URL=file:./data/tunnelquestbot.db'
+    )
+    $updatedEnv = [regex]::Replace(
+        $updatedEnv,
+        '(?m)^(?!\s*#)\s*POSTGRES_MIGRATION_URL\s*=.*(?:\r?\n|$)',
+        ''
+    )
+    $temporaryEnv = "$envPath.sqlite-cutover.tmp"
+    $utf8WithoutBom = New-Object Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText($temporaryEnv, $updatedEnv, $utf8WithoutBom)
+    Move-Item -Force $temporaryEnv $envPath
+    $temporaryEnv = $null
+
+    Remove-Item Env:POSTGRES_MIGRATION_URL
+    $sourceVariableSet = $false
+    docker compose up -d --no-deps --force-recreate tunnelquestbot
+    Assert-LastExitCode 'SQLite bot startup'
+    Start-Sleep -Seconds 10
+
+    $botState = docker inspect tunnelquestbot --format '{{.State.Status}}'
+    Assert-LastExitCode 'Bot status check'
+    $restartCount = [int](docker inspect tunnelquestbot --format '{{.RestartCount}}')
+    Assert-LastExitCode 'Bot restart check'
+    if ($botState.Trim() -ne 'running' -or $restartCount -ne 0) {
+        docker logs --tail 100 tunnelquestbot
+        throw "The SQLite bot is not stable (status=$botState, restarts=$restartCount)"
+    }
+    Test-SqliteImport
+    docker compose ps
+    Assert-LastExitCode 'Final service status'
+
+    $botStopped = $false
+    Write-Host ''
+    Write-Host 'SQLite cutover completed successfully.'
+    Write-Host "Rollback dump: $backupPath"
+    Write-Host 'The stopped postgres container and its data volume were retained.'
+} catch {
+    Write-Host ''
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    if ($botStopped) {
+        docker stop tunnelquestbot 2>$null | Out-Null
+        Write-Host 'The bot was left stopped. PostgreSQL data and any completed backup were retained.'
+        Write-Host 'Correct the reported problem before retrying or follow the rollback procedure.'
+    }
+    exit 1
+} finally {
+    if ($null -ne $temporaryEnv -and (Test-Path $temporaryEnv)) {
+        Remove-Item -Force $temporaryEnv -ErrorAction SilentlyContinue
+    }
+    if ($sourceVariableSet) {
+        Remove-Item Env:POSTGRES_MIGRATION_URL -ErrorAction SilentlyContinue
+    }
+}

--- a/migrate-postgres-to-sqlite.ps1
+++ b/migrate-postgres-to-sqlite.ps1
@@ -16,7 +16,10 @@ $migrationCompose = @(
 $sourceVariableSet = $false
 $botStopped = $false
 $backupPath = $null
+$environmentBackupPath = $null
 $temporaryEnv = $null
+$environmentSwitched = $false
+$postgresStopped = $false
 
 function Assert-LastExitCode([string]$Action) {
     if ($LASTEXITCODE -ne 0) {
@@ -53,6 +56,33 @@ function Wait-ForImport {
     throw 'The PostgreSQL import did not finish within two minutes'
 }
 
+function Get-PostgresCounts([hashtable]$PostgresEnvironment) {
+    $query = @'
+SELECT json_build_object(
+  'User', (SELECT count(*) FROM public."User"),
+  'Watch', (SELECT count(*) FROM public."Watch"),
+  'BlockedPlayer', (SELECT count(*) FROM public."BlockedPlayer"),
+  'BlockedPlayerByWatch', (SELECT count(*) FROM public."BlockedPlayerByWatch"),
+  'PlayerLink', (SELECT count(*) FROM public."PlayerLink")
+)::text;
+'@
+    $output = (
+        $query |
+            docker exec -i postgres psql `
+                -U $PostgresEnvironment.POSTGRES_USER `
+                -d $PostgresEnvironment.POSTGRES_DB -At |
+            Out-String
+    ).Trim()
+    Assert-LastExitCode 'PostgreSQL row-count query'
+    try {
+        $counts = $output | ConvertFrom-Json
+    } catch {
+        throw 'PostgreSQL returned an invalid row-count result'
+    }
+    Write-Host "PostgreSQL counts: $output"
+    return $counts
+}
+
 function Test-SqliteImport {
     $verification = @'
 const Database = require('better-sqlite3');
@@ -73,8 +103,26 @@ db.close();
 console.log(JSON.stringify({ counts, marker, foreignKeyFailures, integrity }));
 if (marker !== 1 || foreignKeyFailures !== 0 || integrity !== 'ok') process.exit(1);
 '@
-    $verification | docker exec -i tunnelquestbot node
+    $output = ($verification | docker exec -i tunnelquestbot node | Out-String).Trim()
     Assert-LastExitCode 'SQLite verification'
+    try {
+        $state = $output | ConvertFrom-Json
+    } catch {
+        throw 'SQLite returned an invalid verification result'
+    }
+    Write-Host "SQLite verification: $output"
+    return $state
+}
+
+function Compare-RowCounts([object]$PostgresCounts, [object]$SqliteCounts) {
+    foreach ($table in @('User', 'Watch', 'BlockedPlayer', 'BlockedPlayerByWatch', 'PlayerLink')) {
+        $source = [Int64]$PostgresCounts.$table
+        $target = [Int64]$SqliteCounts.$table
+        if ($source -ne $target) {
+            throw "Row-count mismatch for $table (PostgreSQL=$source, SQLite=$target)"
+        }
+    }
+    Write-Host 'PostgreSQL and SQLite row counts match.'
 }
 
 try {
@@ -156,6 +204,9 @@ try {
     New-Item -ItemType Directory -Force -Path $BackupDirectory | Out-Null
     $stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
     $backupPath = Join-Path $BackupDirectory "tqb-before-sqlite-$stamp.sql"
+    $environmentBackupPath = Join-Path $BackupDirectory "tqb-before-sqlite-$stamp.env"
+    Copy-Item -LiteralPath $envPath -Destination $environmentBackupPath
+    Write-Host "Saved original environment: $environmentBackupPath"
     $containerBackup = '/tmp/tqb-before-sqlite.sql'
     docker exec postgres sh -ec `
         'umask 077; pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" > /tmp/tqb-before-sqlite.sql'
@@ -173,14 +224,17 @@ try {
         throw 'The PostgreSQL dump did not pass validation'
     }
     Write-Host "Validated PostgreSQL backup: $backupPath ($($backup.Length) bytes)"
+    $postgresCounts = Get-PostgresCounts $postgresEnvironment
 
-    docker compose @migrationCompose up -d --no-deps --force-recreate tunnelquestbot
+    docker compose @migrationCompose up -d --force-recreate tunnelquestbot
     Assert-LastExitCode 'Migration bot startup'
     Wait-ForImport
-    Test-SqliteImport
+    $sqliteState = Test-SqliteImport
+    Compare-RowCounts $postgresCounts $sqliteState.counts
 
     docker compose @migrationCompose stop postgres
     Assert-LastExitCode 'PostgreSQL shutdown'
+    $postgresStopped = $true
 
     $updatedEnv = [regex]::Replace(
         $envText,
@@ -197,10 +251,11 @@ try {
     [IO.File]::WriteAllText($temporaryEnv, $updatedEnv, $utf8WithoutBom)
     Move-Item -Force $temporaryEnv $envPath
     $temporaryEnv = $null
+    $environmentSwitched = $true
 
     Remove-Item Env:POSTGRES_MIGRATION_URL
     $sourceVariableSet = $false
-    docker compose up -d --no-deps --force-recreate tunnelquestbot
+    docker compose up -d --force-recreate tunnelquestbot
     Assert-LastExitCode 'SQLite bot startup'
     Start-Sleep -Seconds 10
 
@@ -212,20 +267,44 @@ try {
         docker logs --tail 100 tunnelquestbot
         throw "The SQLite bot is not stable (status=$botState, restarts=$restartCount)"
     }
-    Test-SqliteImport
+    $sqliteState = Test-SqliteImport
+    Compare-RowCounts $postgresCounts $sqliteState.counts
     docker compose ps
     Assert-LastExitCode 'Final service status'
 
     $botStopped = $false
+    $environmentSwitched = $false
+    $postgresStopped = $false
     Write-Host ''
     Write-Host 'SQLite cutover completed successfully.'
     Write-Host "Rollback dump: $backupPath"
+    Write-Host "Rollback environment: $environmentBackupPath"
     Write-Host 'The stopped postgres container and its data volume were retained.'
 } catch {
     Write-Host ''
     Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
     if ($botStopped) {
         docker stop tunnelquestbot 2>$null | Out-Null
+        if ($environmentSwitched) {
+            try {
+                $temporaryEnv = "$envPath.sqlite-cutover-restore.tmp"
+                $restoreEncoding = New-Object Text.UTF8Encoding($false)
+                [IO.File]::WriteAllText($temporaryEnv, $envText, $restoreEncoding)
+                Move-Item -Force $temporaryEnv $envPath
+                $temporaryEnv = $null
+                Write-Host 'Restored the original PostgreSQL DATABASE_URL in .env.'
+            } catch {
+                Write-Host "WARNING: Could not restore .env automatically: $($_.Exception.Message)" -ForegroundColor Yellow
+            }
+        }
+        if ($postgresStopped) {
+            docker start postgres 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host 'Restarted the retained PostgreSQL container.'
+            } else {
+                Write-Host 'WARNING: Could not restart the PostgreSQL container automatically.' -ForegroundColor Yellow
+            }
+        }
         Write-Host 'The bot was left stopped. PostgreSQL data and any completed backup were retained.'
         Write-Host 'Correct the reported problem before retrying or follow the rollback procedure.'
     }

--- a/start.bat
+++ b/start.bat
@@ -1,1 +1,6 @@
-@start docker-compose.exe up -d
+@echo off
+setlocal
+cd /d "%~dp0"
+docker compose up -d
+if errorlevel 1 exit /b %errorlevel%
+docker compose ps

--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0assert-sqlite-ready.ps1"
+if errorlevel 1 exit /b %errorlevel%
 docker compose up -d
 if errorlevel 1 exit /b %errorlevel%
 docker compose ps

--- a/stop.bat
+++ b/stop.bat
@@ -1,1 +1,6 @@
-@start docker-compose.exe down --remove-orphans
+@echo off
+setlocal
+cd /d "%~dp0"
+docker compose stop
+if errorlevel 1 exit /b %errorlevel%
+docker compose ps -a

--- a/tests/cutover.Tests.ps1
+++ b/tests/cutover.Tests.ps1
@@ -1,0 +1,176 @@
+#requires -Version 5.1
+# Process-level regression tests; Docker is replaced with a synthetic stand-in.
+param(
+    [string]$Scenario,
+    [string]$FixtureDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($Scenario) {
+    $global:LASTEXITCODE = 0
+    if ($Scenario.StartsWith('ready-')) {
+        & (Join-Path $FixtureDirectory 'assert-sqlite-ready.ps1')
+        exit $LASTEXITCODE
+    }
+
+    $global:tqbBotRunning = $true
+    $global:tqbVerificationCount = 0
+    $global:tqbLiveCounts = $false
+    $tracePath = Join-Path $FixtureDirectory 'trace.txt'
+    function Start-Sleep { }
+    function docker {
+        $command = $args -join ' '
+        $global:LASTEXITCODE = 0
+        Add-Content -LiteralPath $tracePath -Value $command
+        if ($command -eq 'compose version') { return 'Docker Compose synthetic' }
+        if ($command -eq 'compose pull tunnelquestbot') { return }
+        if ($command -eq 'compose config --format json') {
+            return '{"services":{"tunnelquestbot":{"image":"synthetic:image"}}}'
+        }
+        if ($command.StartsWith('run --rm --entrypoint sh synthetic:image')) { return }
+        if ($command -eq 'inspect postgres') {
+            return '[{"Config":{"Env":["POSTGRES_USER=test","POSTGRES_PASSWORD=fake","POSTGRES_DB=test"]}}]'
+        }
+        if ($command -eq 'inspect postgres --format {{.State.Health.Status}}') { return 'healthy' }
+        if ($command.EndsWith('config --quiet')) { return }
+        if ($command.EndsWith('stop tunnelquestbot') -or $command -eq 'stop tunnelquestbot') {
+            $global:tqbBotRunning = $false
+            return
+        }
+        if ($command.EndsWith('up -d postgres') -or $command.EndsWith('stop postgres') -or $command -eq 'start postgres') { return }
+        if ($command.StartsWith('exec postgres sh -ec ')) { return }
+        if ($command.StartsWith('cp postgres:/tmp/tqb-before-sqlite.sql ')) {
+            [IO.File]::WriteAllText($args[2], ('-' * 1200) + "`n-- PostgreSQL database dump complete`n")
+            return
+        }
+        if ($command -eq 'exec postgres rm -f /tmp/tqb-before-sqlite.sql') { return }
+        if ($command.StartsWith('exec -i postgres psql ')) {
+            if ($global:tqbBotRunning) { throw 'Source counted while bot was running' }
+            return '{"User":1,"Watch":1,"BlockedPlayer":1,"BlockedPlayerByWatch":1,"PlayerLink":1}'
+        }
+        if ($command.Contains('run --rm --no-deps -T --entrypoint sh tunnelquestbot -ec')) {
+            if ($global:tqbBotRunning) { throw 'Importer ran while bot was serving traffic' }
+            if (-not $command.Contains('prisma migrate deploy && node ./build/prisma/import-postgres.js')) {
+                throw 'Offline importer command was changed'
+            }
+            if ($Scenario -eq 'import-failure') { $global:LASTEXITCODE = 1 }
+            return
+        }
+        if ($command -eq 'compose run --rm --no-deps -T --entrypoint node tunnelquestbot') {
+            $global:tqbVerificationCount++
+            if ($global:tqbVerificationCount -eq 1 -and $global:tqbBotRunning) {
+                throw 'Initial reconciliation ran while bot was serving traffic'
+            }
+            if (($Scenario -eq 'pre-integrity-failure' -and -not $global:tqbLiveCounts) -or
+                ($Scenario -eq 'post-integrity-failure' -and $global:tqbLiveCounts)) {
+                $global:LASTEXITCODE = 1
+            }
+            $watchCount = 1
+            if ($Scenario -eq 'count-mismatch') { $watchCount = 0 }
+            if ($global:tqbLiveCounts -and $Scenario -eq 'traffic-add') { $watchCount = 2 }
+            if ($global:tqbLiveCounts -and $Scenario -eq 'traffic-delete') { $watchCount = 0 }
+            return (@{
+                counts = @{ User = 1; Watch = $watchCount; BlockedPlayer = 1; BlockedPlayerByWatch = 1; PlayerLink = 1 }
+                marker = 1; foreignKeyFailures = 0; integrity = 'ok'
+            } | ConvertTo-Json -Compress)
+        }
+        if ($command -eq 'compose up -d --force-recreate tunnelquestbot') {
+            if ($global:tqbVerificationCount -ne 1) { throw 'Bot started before offline verification' }
+            if ([IO.File]::ReadAllText((Join-Path $FixtureDirectory '.env')) -notmatch 'DATABASE_URL=file:') {
+                throw 'Bot started before switching configuration'
+            }
+            $global:tqbBotRunning = $true
+            $global:tqbLiveCounts = $true
+            if ($Scenario -eq 'startup-failure') { $global:LASTEXITCODE = 1 }
+            return
+        }
+        if ($command -eq 'inspect tunnelquestbot --format {{.State.Status}}') {
+            if ($Scenario -eq 'unstable-bot') { return 'restarting' }
+            return 'running'
+        }
+        if ($command -eq 'inspect tunnelquestbot --format {{.RestartCount}}') {
+            if ($Scenario -eq 'unstable-bot') { return '1' }
+            return '0'
+        }
+        if ($command -eq 'logs --tail 100 tunnelquestbot' -or $command -eq 'compose ps') { return }
+        throw "Unexpected Docker command: $command"
+    }
+
+    & (Join-Path $FixtureDirectory 'migrate-postgres-to-sqlite.ps1') -Force -BackupDirectory (Join-Path $FixtureDirectory 'backups')
+    exit $LASTEXITCODE
+}
+
+function Assert-Test([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+
+$sourceDirectory = Split-Path $PSScriptRoot -Parent
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ('tqb-cutover-tests-' + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $testRoot | Out-Null
+try {
+    foreach ($case in @('success', 'traffic-add', 'traffic-delete', 'count-mismatch', 'import-failure', 'startup-failure', 'unstable-bot', 'pre-integrity-failure', 'post-integrity-failure', 'ready-sqlite', 'ready-postgres', 'ready-invalid', 'ready-duplicate')) {
+        $fixture = Join-Path $testRoot $case
+        New-Item -ItemType Directory -Path $fixture | Out-Null
+        Copy-Item (Join-Path $sourceDirectory '*.ps1') $fixture
+        $originalEnv = "DATABASE_URL=postgresql://test:fake@postgres/test`n"
+        if ($case -eq 'ready-sqlite') { $originalEnv = "DATABASE_URL=file:./data/test.db`n" }
+        if ($case -eq 'ready-invalid') { $originalEnv = "DATABASE_URL=invalid`n" }
+        if ($case -eq 'ready-duplicate') { $originalEnv += $originalEnv }
+        [IO.File]::WriteAllText((Join-Path $fixture '.env'), $originalEnv)
+        $processInfo = New-Object Diagnostics.ProcessStartInfo
+        $processInfo.FileName = Join-Path $PSHOME 'powershell.exe'
+        $processInfo.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -Scenario {1} -FixtureDirectory "{2}"' -f $PSCommandPath, $case, $fixture
+        $processInfo.UseShellExecute = $false
+        $processInfo.RedirectStandardOutput = $true
+        $processInfo.RedirectStandardError = $true
+        $child = [Diagnostics.Process]::Start($processInfo)
+        try {
+            $stdout = $child.StandardOutput.ReadToEndAsync()
+            $stderr = $child.StandardError.ReadToEndAsync()
+            if (-not $child.WaitForExit(30000)) {
+                $child.Kill()
+                throw "$case timed out"
+            }
+            $output = $stdout.Result + $stderr.Result
+            $exitCode = $child.ExitCode
+        } finally {
+            $child.Dispose()
+        }
+        $expectedSuccess = $case -in @('success', 'traffic-add', 'traffic-delete', 'ready-sqlite')
+        Assert-Test (($exitCode -eq 0) -eq $expectedSuccess) "$case exited $exitCode : $output"
+        $expectedFailures = @{
+            'count-mismatch' = 'Row-count mismatch for Watch'
+            'import-failure' = 'PostgreSQL import failed with exit code'
+            'startup-failure' = 'SQLite bot startup failed with exit code'
+            'unstable-bot' = 'The SQLite bot is not stable'
+            'pre-integrity-failure' = 'SQLite verification failed with exit code'
+            'post-integrity-failure' = 'SQLite verification failed with exit code'
+            'ready-postgres' = 'PostgreSQL cutover is pending'
+            'ready-invalid' = 'DATABASE_URL must be a persistent SQLite file URL'
+            'ready-duplicate' = 'Expected exactly one active DATABASE_URL'
+        }
+        if ($expectedFailures.ContainsKey($case)) {
+            Assert-Test (($output | Out-String).Contains($expectedFailures[$case])) "$case failed for the wrong reason: $output"
+        }
+        $finalEnv = [IO.File]::ReadAllText((Join-Path $fixture '.env'))
+        if (-not $case.StartsWith('ready-')) {
+            $trace = [IO.File]::ReadAllText((Join-Path $fixture 'trace.txt'))
+            $activated = $case -in @('success', 'traffic-add', 'traffic-delete', 'startup-failure', 'unstable-bot', 'post-integrity-failure')
+            if ($activated) {
+                Assert-Test ($finalEnv -match 'DATABASE_URL=file:') "$case restored stale PostgreSQL configuration"
+                Assert-Test (-not $trace.Contains("`nstart postgres")) "$case restarted the old database after activation"
+            } else {
+                Assert-Test ($finalEnv -eq $originalEnv) "$case changed the original configuration"
+                Assert-Test (-not $trace.Contains('compose up -d --force-recreate tunnelquestbot')) "$case started the bot after failed validation"
+            }
+            if (-not $expectedSuccess) {
+                Assert-Test ($trace.Contains("`nstop tunnelquestbot")) "$case did not leave the bot stopped"
+            }
+        }
+        Write-Host "PASS $case"
+    }
+} finally {
+    Remove-Item -LiteralPath $testRoot -Recurse -Force
+}

--- a/update.bat
+++ b/update.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 cd /d "%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0assert-sqlite-ready.ps1"
+if errorlevel 1 exit /b %errorlevel%
 docker compose pull
 if errorlevel 1 exit /b %errorlevel%
 docker compose up -d

--- a/update.bat
+++ b/update.bat
@@ -1,1 +1,8 @@
-@start docker-compose.exe up -d --pull always
+@echo off
+setlocal
+cd /d "%~dp0"
+docker compose pull
+if errorlevel 1 exit /b %errorlevel%
+docker compose up -d
+if errorlevel 1 exit /b %errorlevel%
+docker compose ps


### PR DESCRIPTION
## Summary
- update the production-only Compose bundle for SQLite and Redis health checks
- modernize Windows deployment scripts for Docker Compose v2 and visible failures
- block routine startup until the one-time PostgreSQL cutover completes
- add a PowerShell 5.1-compatible cutover with private SQL/.env backups, independent row reconciliation, integrity checks, dependency startup, and failure recovery
- document first-time cutover, rollback, and routine operations

## Validation
- parsed and exercised environment rewrite logic with Windows PowerShell 5.1
- validated regular and migration Compose configurations
- asserted persistent SQLite, Redis health dependency, and migration overlay invariants
- completed an independent deployment safety review and addressed all findings

## Deployment dependency
Merge and promote the SQLite-capable production image from #125 before merging or using this deployment update.